### PR TITLE
Change getter visibility so it can be overridden

### DIFF
--- a/src/java/com/marklogic/developer/corb/Manager.java
+++ b/src/java/com/marklogic/developer/corb/Manager.java
@@ -348,16 +348,15 @@ public class Manager implements Runnable {
     	this.properties = props;
     }
     
-    //package access only
-    protected Properties getProperties(){
+    public Properties getProperties(){
     	return this.properties;
     }
     
-    protected TransformOptions getOptions() {
+    public TransformOptions getOptions() {
         return options;
     }
     
-    protected ContentSource getContentSource(){
+    public ContentSource getContentSource(){
     	return this.contentSource;
     }
 


### PR DESCRIPTION
Consider opening these up so the wrapper class can override these methods. With package or default access, they cannot be overridden by a class in a different package.
