### PR TITLE
When METRICS-LOG-LEVEL=NONE then do not log to console.

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/JobStats.java
+++ b/src/main/java/com/marklogic/developer/corb/JobStats.java
@@ -593,22 +593,25 @@ public class JobStats extends BaseMonitor {
      * @param logToConsole whether to log to console
      */
     public void logMetrics(String message, boolean concise, boolean logToConsole) {
-        String processModule = options.getMetricsModule();
-        Document doc = toXML(concise);
-        String metricsLogMessage = toJSON(doc);
-        if (logToConsole) {
-            LOG.info(metricsLogMessage);
-        }
+        String logLevel = options.getLogMetricsToServerLog();
+        if (options.isMetricsLoggingEnabled(logLevel)) {
+            String processModule = options.getMetricsModule();
+            Document doc = toXML(concise);
+            String metricsLogMessage = toJSON(doc);
+            if (logToConsole) {
+                LOG.info(metricsLogMessage);
+            }
 
-        String metricsDocument;
-        if (isJavaScriptModule(processModule)) {
-            metricsDocument = metricsLogMessage;
-        } else {
-            metricsDocument = XmlUtils.documentToString(doc);
-        }
+            String metricsDocument;
+            if (isJavaScriptModule(processModule)) {
+                metricsDocument = metricsLogMessage;
+            } else {
+                metricsDocument = XmlUtils.documentToString(doc);
+            }
 
-        executeModule(metricsDocument);
-        logToServer(message, metricsLogMessage);
+            executeModule(metricsDocument);
+            logToServer(message, metricsLogMessage);
+        }
     }
 
     /**

--- a/src/test/java/com/marklogic/developer/corb/JobStatsTest.java
+++ b/src/test/java/com/marklogic/developer/corb/JobStatsTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.*;
 import java.util.concurrent.CompletionService;
+import java.util.logging.Logger;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
@@ -490,11 +491,6 @@ class JobStatsTest {
 
     @Test
     void testAddFailedUris() {
-
-    }
-
-    @Test
-    void testAddFailedUrisWhenNull() {
         Manager manager = mock(Manager.class);
         PausableThreadPoolExecutor threadPoolExecutor = mock(PausableThreadPoolExecutor.class);
         List<String> uris = new ArrayList<>(1);
@@ -512,29 +508,31 @@ class JobStatsTest {
             fail();
         }
     }
-	/*
-	 * 1: Log once at the start and once at the end XML
-	 * 		Log to DB Document
-	 * 		Log to ML Error Log
-	 * 		Log to Java console
-	 * 2: Log once at the start and once at the end JSON
-	 * 		Log to DB Document
-	 * 		Log to ML Error Log
-	 * 		Log to Java console
-	 * 3: Log periodically XML or JSON
-	 * 		Fewer fields in concise mode for periodic logging
-	 * 		End time and average transaction time is shown on the last entry
-	 * 		Should only have one entry with end time
-	 * 		Should pause syncing when job is paused
-	 * 		Should log one extra full record when pausing
-	 * 5: COLLECTION Name
-	 * 6: Root directory
-	 * 7: Job run location can't be found and Job name not specified?
-	 * 8: Job Server Port
-	 * 		Specify single port
-	 * 		Specify range
-	 * 		Specify multiple ranges or multiple ports
-	 * 9: UI Validation
-	 * 		All fields
-	 */
+
+    @Test
+    void testLogMetrics() throws CorbException {
+        TransformOptions transformOptions = new TransformOptions();
+        transformOptions.setLogMetricsToServerLog("INFO");
+        Manager manager = mock(Manager.class);
+        ContentSourcePool contentSourcePool = mock(ContentSourcePool.class);
+        when(contentSourcePool.get()).thenThrow(new RuntimeException("boom!"));
+        when(manager.getOptions()).thenReturn(transformOptions);
+        when(manager.getContentSourcePool()).thenReturn(contentSourcePool);
+
+        JobStats jobStats = new JobStats(manager);
+        assertThrows(RuntimeException.class, () -> jobStats.logMetrics("test", true, true));
+    }
+
+    @Test
+    void testLogMetricsWhenMetricsLogLevelNone() throws CorbException {
+        TransformOptions transformOptions = new TransformOptions();
+        transformOptions.setLogMetricsToServerLog("NONE");
+        Manager manager = mock(Manager.class);
+        ContentSourcePool contentSourcePool = mock(ContentSourcePool.class);
+        when(contentSourcePool.get()).thenThrow(new RuntimeException("boom!"));
+        when(manager.getOptions()).thenReturn(transformOptions);
+        when(manager.getContentSourcePool()).thenReturn(contentSourcePool);
+        JobStats jobStats = new JobStats(manager);
+        assertDoesNotThrow( () -> jobStats.logMetrics("test", true, true));
+    }
 }


### PR DESCRIPTION
This can be used to avoid no entry name exceptions that can occur from document('') calls in the jobStatsToJson.xsl when transforming Metrics XML to JSON format when Saxon 10 is on the classpath, which has errors when source is from jar file.