### PR TITLE
CoRB Options builder with ability to either download options properties file or invoke jobs from UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ configurations {
 
 dependencies {
     compileOnly 'org.jetbrains:annotations:26.1.0'
-    api 'com.marklogic:marklogic-xcc:12.0.1'
+    api "com.marklogic:marklogic-xcc:$xccVersion"
     // JavaScript libraries are  bundled in a fat jar for the UI
     shadow "org.webjars.npm:alpinejs:$alpineVersion"
     implementation "org.webjars.npm:alpinejs:$alpineVersion"
@@ -130,8 +130,8 @@ shadowJar {
     manifest {
         attributes 'Application-Version': project.version
         attributes 'Build-date' : new Date()
-        attributes 'Main-Class' : 'com.marklogic.developer.corb.Manager'
-
+        attributes 'Main-Class' : 'com.marklogic.developer.corb.JobServer'
+        attributes 'Class-Path': "markLogic-xcc-${xccVersion}.jar"
         attributes 'Name': 'com/marklogic/developer/corb/'
         attributes 'Specification-Title' : 'corb'
         attributes 'Specification-Version' : project.version

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -5,5 +5,5 @@ mlUsername=admin
 mlPassword=admin
 xccProtocol=xcc
 mlGradleVersion=4.7.0
-corbVersion=2.5.7
-xccVersion=11.1.0
+corbVersion=2.6.0
+xccVersion=12.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,6 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 alpineVersion=3.15.8
 externalsortinginjavaVersion=0.6.6
 junitVersion=5.14.3
+xccVersion=12.0.1
 # 2.1.2 First version built and published with Gradle
 version=2.6.0

--- a/src/main/java/com/marklogic/developer/corb/JobBuilderHandler.java
+++ b/src/main/java/com/marklogic/developer/corb/JobBuilderHandler.java
@@ -1,0 +1,199 @@
+/*
+ * * Copyright (c) 2004-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * *
+ * * The use of the Apache License does not indicate that this project is
+ * * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import com.marklogic.developer.corb.util.IOUtils;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Handles Job Server requests for the browser-based options builder.
+ */
+public class JobBuilderHandler implements HttpHandler {
+
+    public static final String BUILDER_ROOT_PATH = "/builder";
+    public static final String BUILDER_METADATA_PATH = BUILDER_ROOT_PATH + "/metadata";
+    public static final String BUILDER_PROPERTIES_PATH = BUILDER_ROOT_PATH + "/properties";
+    public static final String BUILDER_JOBS_PATH = BUILDER_ROOT_PATH + "/jobs";
+
+    private static final Logger LOG = Logger.getLogger(JobBuilderHandler.class.getName());
+    private static final Charset UTF_8 = StandardCharsets.UTF_8;
+
+    private final JobBuilderService service;
+
+    JobBuilderHandler(JobServer jobServer) {
+        this(new JobBuilderService(new EmbeddedJobLauncher(jobServer)));
+    }
+
+    JobBuilderHandler(JobBuilderService service) {
+        this.service = service;
+    }
+
+    static boolean canHandle(String path) {
+        return path != null && path.startsWith(BUILDER_ROOT_PATH);
+    }
+
+    @Override
+    public void handle(HttpExchange httpExchange) throws IOException {
+        JobServer.alowXSS(httpExchange);
+        String method = httpExchange.getRequestMethod();
+        String path = httpExchange.getRequestURI().getPath();
+
+        if ("OPTIONS".equalsIgnoreCase(method)) {
+            httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_NO_CONTENT, -1);
+            return;
+        }
+
+        try {
+            if (BUILDER_METADATA_PATH.equals(path)) {
+                requireMethod(method, "GET");
+                writeResponse(httpExchange, HttpURLConnection.HTTP_OK, JobServer.MIME_JSON, service.buildMetadataJson(), null);
+            } else if (BUILDER_PROPERTIES_PATH.equals(path)) {
+                requireMethod(method, "POST");
+                Map<String, String> submittedValues = readFormValues(httpExchange);
+                writeResponse(
+                    httpExchange,
+                    HttpURLConnection.HTTP_OK,
+                    "text/plain; charset=utf-8",
+                    service.buildPropertiesFile(submittedValues),
+                    "attachment; filename=\"" + service.resolveDownloadFilename(submittedValues) + "\"");
+            } else if (BUILDER_JOBS_PATH.equals(path)) {
+                requireMethod(method, "POST");
+                Map<String, String> submittedValues = readFormValues(httpExchange);
+                writeResponse(httpExchange, HttpURLConnection.HTTP_OK, JobServer.MIME_JSON, service.launchJob(submittedValues).toJson(), null);
+            } else {
+                writeError(httpExchange, HttpURLConnection.HTTP_NOT_FOUND, "Unknown options builder endpoint");
+            }
+        } catch (IllegalArgumentException ex) {
+            writeError(httpExchange, HttpURLConnection.HTTP_BAD_REQUEST, ex.getMessage());
+        } catch (Exception ex) {
+            LOG.log(Level.SEVERE, "Unable to process options builder request", ex);
+            writeError(httpExchange, HttpURLConnection.HTTP_INTERNAL_ERROR, ex.getMessage());
+        }
+    }
+
+    private void requireMethod(String actualMethod, String expectedMethod) {
+        if (!expectedMethod.equalsIgnoreCase(actualMethod)) {
+            throw new IllegalArgumentException("Unsupported method " + actualMethod + " for options builder endpoint");
+        }
+    }
+
+    private Map<String, String> readFormValues(HttpExchange httpExchange) throws IOException {
+        String body = new String(IOUtils.toByteArray(httpExchange.getRequestBody()), UTF_8);
+        return decodeFormValues(body);
+    }
+
+    private Map<String, String> decodeFormValues(String formBody) throws IOException {
+        Map<String, String> result = new HashMap<>();
+        if (formBody == null || formBody.isEmpty()) {
+            return result;
+        }
+
+        String[] params = formBody.split("&");
+        for (String param : params) {
+            String[] pair = param.split("=", 2);
+            String key = URLDecoder.decode(pair[0], UTF_8.name());
+            String value = pair.length > 1 ? URLDecoder.decode(pair[1], UTF_8.name()) : "";
+            result.put(key, value);
+        }
+        return result;
+    }
+
+    private void writeError(HttpExchange httpExchange, int statusCode, String message) throws IOException {
+        String safeMessage = message == null ? "" : message;
+        writeResponse(httpExchange, statusCode, JobServer.MIME_JSON,
+            "{\"error\":\"" + JobBuilderService.escapeJson(safeMessage) + "\"}", null);
+    }
+
+    private void writeResponse(HttpExchange httpExchange, int statusCode, String contentType, String body, String contentDisposition)
+        throws IOException {
+        byte[] bytes = body.getBytes(UTF_8);
+        httpExchange.getResponseHeaders().set(JobServer.HEADER_CONTENT_TYPE, contentType);
+        if (contentDisposition != null) {
+            httpExchange.getResponseHeaders().set("Content-Disposition", contentDisposition);
+        }
+        httpExchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream outputStream = httpExchange.getResponseBody()) {
+            outputStream.write(bytes);
+            outputStream.flush();
+        }
+    }
+
+    static class EmbeddedJobLauncher implements JobBuilderService.JobLauncher {
+
+        private static final Logger LAUNCHER_LOG = Logger.getLogger(EmbeddedJobLauncher.class.getName());
+
+        private final JobServer jobServer;
+
+        EmbeddedJobLauncher(JobServer jobServer) {
+            this.jobServer = jobServer;
+        }
+
+        @Override
+        public JobBuilderService.JobLaunchResult launch(Properties properties) throws Exception {
+            final EmbeddedManager manager = new EmbeddedManager();
+            manager.init(properties);
+            manager.jobId = UUID.randomUUID().toString();
+            jobServer.addManager(manager);
+
+            Thread jobThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        manager.run();
+                    } catch (Exception ex) {
+                        LAUNCHER_LOG.log(Level.SEVERE, "Options builder job failed", ex);
+                    } finally {
+                        manager.close();
+                    }
+                }
+            }, "corb-builder-" + manager.getJobId());
+            jobThread.start();
+
+            return new JobBuilderService.JobLaunchResult(
+                manager.getJobId(),
+                manager.options.getJobName(),
+                JobServer.HTTP_RESOURCE_PATH + manager.getJobId());
+        }
+    }
+
+    static class EmbeddedManager extends Manager {
+        @Override
+        public void close() {
+            if (scheduledExecutor != null) {
+                scheduledExecutor.shutdown();
+            }
+            IOUtils.closeQuietly(csp);
+        }
+    }
+}

--- a/src/main/java/com/marklogic/developer/corb/JobBuilderService.java
+++ b/src/main/java/com/marklogic/developer/corb/JobBuilderService.java
@@ -1,0 +1,894 @@
+/*
+ * * Copyright (c) 2004-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * *
+ * * The use of the Apache License does not indicate that this project is
+ * * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.marklogic.developer.corb.util.StringUtils.isBlank;
+import static com.marklogic.developer.corb.util.StringUtils.isNotBlank;
+import static com.marklogic.developer.corb.util.StringUtils.trim;
+
+/**
+ * Provides metadata and serialization helpers for the Job Server options builder UI.
+ */
+public class JobBuilderService {
+
+    static final String PARAM_ADDITIONAL_PROPERTIES = "builder.additionalProperties";
+    static final String PARAM_DOWNLOAD_FILE_NAME = "builder.downloadFileName";
+    static final String DEFAULT_PROPERTIES_FILE_NAME = "corb-job.properties";
+
+    private static final Logger LOG = Logger.getLogger(JobBuilderService.class.getName());
+
+    private static final String GROUP_CONNECTION = "connection";
+    private static final String GROUP_SECURITY = "security";
+    private static final String GROUP_INPUT = "input";
+    private static final String GROUP_PROCESSING = "processing";
+    private static final String GROUP_EXECUTION = "execution";
+    private static final String GROUP_EXPORT = "export";
+    private static final String GROUP_MONITORING = "monitoring";
+    private static final String GROUP_RETRY = "retry";
+    private static final String GROUP_ADVANCED = "advanced";
+
+    private static final Set<String> BOOLEAN_OPTIONS = setOf(
+        Options.CONTENT_SOURCE_RENEW,
+        Options.DISK_QUEUE,
+        Options.EXPORT_FILE_AS_ZIP,
+        Options.EXPORT_FILE_REQUIRE_PROCESS_MODULE,
+        Options.EXPORT_FILE_SORT,
+        Options.FAIL_ON_ERROR,
+        Options.INSTALL,
+        Options.LOADER_BASE64_ENCODE,
+        Options.LOADER_SET_URIS_BATCH_REF,
+        Options.LOADER_USE_ENVELOPE,
+        Options.METADATA_TO_PROCESS_MODULE,
+        Options.PRE_POST_BATCH_ALWAYS_EXECUTE,
+        Options.URIS_REDACTED,
+        Options.XCC_HTTPCOMPLIANT,
+        Options.XCC_URL_ENCODE_COMPONENTS,
+        Options.XML_SCHEMA_HONOUR_ALL_SCHEMALOCATIONS
+    );
+
+    private static final Set<String> NUMBER_OPTIONS = setOf(
+        Options.BATCH_SIZE,
+        Options.COMMAND_FILE_POLL_INTERVAL,
+        Options.CONTENT_SOURCE_RENEW_INTERVAL,
+        Options.DISK_QUEUE_MAX_IN_MEMORY_SIZE,
+        Options.EXIT_CODE_IGNORED_ERRORS,
+        Options.EXIT_CODE_NO_URIS,
+        Options.EXPORT_FILE_SPLIT_MAX_LINES,
+        Options.MAX_OPTS_FROM_MODULE,
+        Options.METRICS_NUM_FAILED_TRANSACTIONS,
+        Options.METRICS_NUM_SLOW_TRANSACTIONS,
+        Options.METRICS_SYNC_FREQUENCY,
+        Options.NUM_TPS_FOR_ETC,
+        Options.POST_BATCH_MINIMUM_COUNT,
+        Options.PRE_BATCH_MINIMUM_COUNT,
+        Options.QUERY_RETRY_INTERVAL,
+        Options.QUERY_RETRY_LIMIT,
+        Options.THREAD_COUNT,
+        Options.XCC_CONNECTION_HOST_RETRY_LIMIT,
+        Options.XCC_CONNECTION_RETRY_INTERVAL,
+        Options.XCC_CONNECTION_RETRY_LIMIT,
+        Options.XCC_PORT,
+        Options.XCC_TOKEN_DURATION
+    );
+
+    private static final Set<String> PASSWORD_OPTIONS = setOf(
+        Options.XCC_API_KEY,
+        Options.XCC_OAUTH_TOKEN,
+        Options.XCC_PASSWORD,
+        Options.SSL_KEY_PASSWORD,
+        Options.SSL_KEYSTORE_PASSWORD,
+        Options.SSL_TRUSTSTORE_PASSWORD
+    );
+
+    private static final Set<String> TEXTAREA_OPTIONS = setOf(
+        Options.EXPORT_FILE_BOTTOM_CONTENT,
+        Options.EXPORT_FILE_TOP_CONTENT
+    );
+
+    private static final Map<String, String> PLACEHOLDERS = new HashMap<>();
+
+    static {
+        PLACEHOLDERS.put(Options.BATCH_URI_DELIM, ";");
+        PLACEHOLDERS.put(Options.COLLECTION_NAME, "collection-name");
+        PLACEHOLDERS.put(Options.COMMAND_FILE, "/tmp/corb-command.properties");
+        PLACEHOLDERS.put(Options.CONNECTION_POLICY, "ROUND-ROBIN, RANDOM, or LOAD");
+        PLACEHOLDERS.put(Options.DISK_QUEUE_TEMP_DIR, "/tmp/corb-queue");
+        PLACEHOLDERS.put(Options.ERROR_FILE_NAME, "errors.txt");
+        PLACEHOLDERS.put(Options.EXPORT_FILE_DIR, "/tmp/exports");
+        PLACEHOLDERS.put(Options.EXPORT_FILE_NAME, "export.txt");
+        PLACEHOLDERS.put(Options.EXPORT_FILE_SPLIT_MAX_SIZE, "10MB");
+        PLACEHOLDERS.put(Options.JOB_NAME, "nightly-job");
+        PLACEHOLDERS.put(Options.JOB_SERVER_PORT, "8005-8010");
+        PLACEHOLDERS.put(Options.LOADER_PATH, "/envelope/instance");
+        PLACEHOLDERS.put(Options.LOADER_VARIABLE, "URI");
+        PLACEHOLDERS.put(Options.METRICS_DATABASE, "Metrics");
+        PLACEHOLDERS.put(Options.METRICS_MODULE, "/ext/metrics.xqy");
+        PLACEHOLDERS.put(Options.METRICS_ROOT, "/");
+        PLACEHOLDERS.put(Options.MODULE_ROOT, "/");
+        PLACEHOLDERS.put(Options.MODULES_DATABASE, "Modules");
+        PLACEHOLDERS.put(Options.OPTIONS_FILE, "job.properties");
+        PLACEHOLDERS.put(Options.POST_BATCH_MODULE, "/ext/post-batch.xqy");
+        PLACEHOLDERS.put(Options.POST_BATCH_TASK, "com.example.PostBatchTask");
+        PLACEHOLDERS.put(Options.PRE_BATCH_MODULE, "/ext/pre-batch.xqy");
+        PLACEHOLDERS.put(Options.PRE_BATCH_TASK, "com.example.PreBatchTask");
+        PLACEHOLDERS.put(Options.PRIVATE_KEY_FILE, "/path/to/private-key.pem");
+        PLACEHOLDERS.put(Options.PROCESS_MODULE, "/ext/process.xqy");
+        PLACEHOLDERS.put(Options.PROCESS_TASK, "com.example.ProcessTask");
+        PLACEHOLDERS.put(Options.SSL_KEYSTORE, "/path/to/keystore.jks");
+        PLACEHOLDERS.put(Options.SSL_PROPERTIES_FILE, "/path/to/ssl.properties");
+        PLACEHOLDERS.put(Options.SSL_TRUSTSTORE, "/path/to/truststore.jks");
+        PLACEHOLDERS.put(Options.TEMP_DIR, "/tmp");
+        PLACEHOLDERS.put(Options.URIS_FILE, "/path/to/uris.txt");
+        PLACEHOLDERS.put(Options.URIS_MODULE, "/ext/get-uris.xqy");
+        PLACEHOLDERS.put(Options.XCC_BASE_PATH, "/manage/v2");
+        PLACEHOLDERS.put(Options.XCC_CONNECTION_URI, "xcc://user:password@host:8000/content");
+        PLACEHOLDERS.put(Options.XCC_DBNAME, "content");
+        PLACEHOLDERS.put(Options.XCC_HOSTNAME, "localhost");
+        PLACEHOLDERS.put(Options.XCC_PORT, "8000");
+        PLACEHOLDERS.put(Options.XCC_PROTOCOL, "xcc or xccs");
+        PLACEHOLDERS.put(Options.XCC_USERNAME, "admin");
+        PLACEHOLDERS.put(Options.XML_FILE, "/path/to/uris.xml");
+        PLACEHOLDERS.put(Options.XML_NODE, "/*/*");
+        PLACEHOLDERS.put(Options.XML_SCHEMA, "/path/to/schema.xsd");
+        PLACEHOLDERS.put(Options.XML_TEMP_DIR, "/tmp/corb-xml");
+        PLACEHOLDERS.put(Options.ZIP_FILE, "/path/to/uris.zip");
+    }
+
+    private final JobLauncher jobLauncher;
+    private final List<OptionGroup> optionGroups;
+    private final Set<String> supportedOptionNames;
+    private final Map<String, String> optionDescriptions;
+
+    public JobBuilderService(JobLauncher jobLauncher) {
+        this.jobLauncher = jobLauncher;
+        this.optionDescriptions = loadOptionDescriptions();
+        this.optionGroups = buildOptionGroups();
+        this.supportedOptionNames = buildSupportedOptionNames(optionGroups);
+    }
+
+    public String buildMetadataJson() {
+        StringBuilder json = new StringBuilder();
+        json.append('{');
+        json.append("\"groups\":[");
+        for (int i = 0; i < optionGroups.size(); i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append(optionGroups.get(i).toJson());
+        }
+        json.append(']');
+        json.append('}');
+        return json.toString();
+    }
+
+    public String buildPropertiesFile(Map<String, String> submittedValues) {
+        return serializeProperties(buildProperties(submittedValues));
+    }
+
+    public String resolveDownloadFilename(Map<String, String> submittedValues) {
+        String requestedName = trim(getSubmittedValue(submittedValues, PARAM_DOWNLOAD_FILE_NAME));
+        if (isBlank(requestedName)) {
+            return DEFAULT_PROPERTIES_FILE_NAME;
+        }
+
+        String sanitized = requestedName.replace('\\', '-').replace('/', '-').trim();
+        if (isBlank(sanitized)) {
+            return DEFAULT_PROPERTIES_FILE_NAME;
+        }
+        if (!sanitized.toLowerCase(Locale.ENGLISH).endsWith(".properties")) {
+            sanitized += ".properties";
+        }
+        return sanitized;
+    }
+
+    public JobLaunchResult launchJob(Map<String, String> submittedValues) throws Exception {
+        if (jobLauncher == null) {
+            throw new IllegalStateException("A job launcher is required to start jobs from the options builder");
+        }
+        return jobLauncher.launch(buildProperties(submittedValues));
+    }
+
+    protected Properties buildProperties(Map<String, String> submittedValues) {
+        Properties properties = new Properties();
+        mergeAdditionalProperties(properties, getSubmittedValue(submittedValues, PARAM_ADDITIONAL_PROPERTIES));
+        for (String optionName : supportedOptionNames) {
+            String value = trim(getSubmittedValue(submittedValues, optionName));
+            if (isNotBlank(value)) {
+                properties.setProperty(optionName, value);
+            }
+        }
+        return properties;
+    }
+
+    protected List<OptionGroup> getOptionGroups() {
+        return optionGroups;
+    }
+
+    private Set<String> buildSupportedOptionNames(List<OptionGroup> groups) {
+        Set<String> optionNames = new LinkedHashSet<>();
+        for (OptionGroup group : groups) {
+            for (OptionDefinition option : group.options) {
+                optionNames.add(option.name);
+            }
+        }
+        return optionNames;
+    }
+
+    private String getSubmittedValue(Map<String, String> submittedValues, String name) {
+        if (submittedValues.containsKey(name)) {
+            return submittedValues.get(name);
+        }
+        return JobServer.getParameter(submittedValues, name);
+    }
+
+    private void mergeAdditionalProperties(Properties properties, String rawAdditionalProperties) {
+        if (isBlank(rawAdditionalProperties)) {
+            return;
+        }
+
+        Properties additionalProperties = new Properties();
+        try {
+            additionalProperties.load(new StringReader(rawAdditionalProperties));
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to parse additional properties", ex);
+        }
+
+        for (String propertyName : additionalProperties.stringPropertyNames()) {
+            properties.setProperty(propertyName, additionalProperties.getProperty(propertyName));
+        }
+    }
+
+    private String serializeProperties(Properties properties) {
+        List<String> orderedNames = new ArrayList<>();
+        for (OptionGroup group : optionGroups) {
+            for (OptionDefinition option : group.options) {
+                if (properties.containsKey(option.name)) {
+                    orderedNames.add(option.name);
+                }
+            }
+        }
+
+        Set<String> remainingNames = new HashSet<>(properties.stringPropertyNames());
+        remainingNames.removeAll(new HashSet<>(orderedNames));
+        List<String> sortedRemainingNames = new ArrayList<>(remainingNames);
+        Collections.sort(sortedRemainingNames);
+        orderedNames.addAll(sortedRemainingNames);
+
+        StringBuilder builder = new StringBuilder();
+        for (String propertyName : orderedNames) {
+            builder.append(propertyName)
+                .append('=')
+                .append(escapePropertiesValue(properties.getProperty(propertyName)))
+                .append('\n');
+        }
+        return builder.toString();
+    }
+
+    private String escapePropertiesValue(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                case '\n':
+                    builder.append("\\n");
+                    break;
+                case '\r':
+                    builder.append("\\r");
+                    break;
+                case '\t':
+                    builder.append("\\t");
+                    break;
+                default:
+                    if (i == 0 && ch == ' ') {
+                        builder.append("\\ ");
+                    } else {
+                        builder.append(ch);
+                    }
+            }
+        }
+        return builder.toString();
+    }
+
+    private List<OptionGroup> buildOptionGroups() {
+        LinkedHashMap<String, OptionGroupBuilder> builders = new LinkedHashMap<>();
+        builders.put(GROUP_CONNECTION, new OptionGroupBuilder(
+            GROUP_CONNECTION,
+            "Connection",
+            "Configure XCC connection details, pooling behavior, and connection-specific settings.",
+            Arrays.asList(
+                Options.XCC_CONNECTION_URI,
+                Options.XCC_PROTOCOL,
+                Options.XCC_HOSTNAME,
+                Options.XCC_PORT,
+                Options.XCC_DBNAME,
+                Options.XCC_USERNAME,
+                Options.XCC_PASSWORD,
+                Options.XCC_API_KEY,
+                Options.XCC_OAUTH_TOKEN,
+                Options.XCC_BASE_PATH,
+                Options.XCC_GRANT_TYPE,
+                Options.XCC_TOKEN_DURATION,
+                Options.XCC_TOKEN_ENDPOINT,
+                Options.XCC_HTTPCOMPLIANT,
+                Options.XCC_URL_ENCODE_COMPONENTS,
+                Options.XCC_TIME_ZONE,
+                Options.CONNECTION_POLICY,
+                Options.CONTENT_SOURCE_POOL,
+                Options.CONTENT_SOURCE_RENEW,
+                Options.CONTENT_SOURCE_RENEW_INTERVAL
+            )));
+        builders.put(GROUP_SECURITY, new OptionGroupBuilder(
+            GROUP_SECURITY,
+            "Security & SSL",
+            "Manage decryption and SSL/truststore configuration for secure connections.",
+            Arrays.asList(
+                Options.DECRYPTER,
+                Options.JASYPT_PROPERTIES_FILE,
+                Options.PRIVATE_KEY_FILE,
+                Options.PRIVATE_KEY_ALGORITHM,
+                Options.SSL_CONFIG_CLASS,
+                Options.SSL_PROPERTIES_FILE,
+                Options.SSL_CIPHER_SUITES,
+                Options.SSL_ENABLED_PROTOCOLS,
+                Options.SSL_KEYSTORE,
+                Options.SSL_KEYSTORE_TYPE,
+                Options.SSL_KEYSTORE_PASSWORD,
+                Options.SSL_KEY_PASSWORD,
+                Options.SSL_TRUSTSTORE,
+                Options.SSL_TRUSTSTORE_TYPE,
+                Options.SSL_TRUSTSTORE_PASSWORD
+            )));
+        builders.put(GROUP_INPUT, new OptionGroupBuilder(
+            GROUP_INPUT,
+            "Input & Loaders",
+            "Choose where URIs come from and how loader-driven XML or ZIP inputs are interpreted.",
+            Arrays.asList(
+                Options.COLLECTION_NAME,
+                Options.URIS_MODULE,
+                Options.URIS_FILE,
+                Options.URIS_LOADER,
+                Options.URIS_REDACTED,
+                Options.URIS_REPLACE_PATTERN,
+                Options.LOADER_PATH,
+                Options.LOADER_VARIABLE,
+                Options.LOADER_USE_ENVELOPE,
+                Options.LOADER_BASE64_ENCODE,
+                Options.LOADER_SET_URIS_BATCH_REF,
+                Options.XML_FILE,
+                Options.XML_NODE,
+                Options.XML_METADATA,
+                Options.XML_SCHEMA,
+                Options.XML_SCHEMA_HONOUR_ALL_SCHEMALOCATIONS,
+                Options.XML_TEMP_DIR,
+                Options.ZIP_FILE
+            )));
+        builders.put(GROUP_PROCESSING, new OptionGroupBuilder(
+            GROUP_PROCESSING,
+            "Modules & Tasks",
+            "Configure processing modules, tasks, module resolution, and metadata hand-off between job phases.",
+            Arrays.asList(
+                Options.PROCESS_MODULE,
+                Options.PROCESS_TASK,
+                Options.INIT_MODULE,
+                Options.INIT_TASK,
+                Options.PRE_BATCH_MODULE,
+                Options.PRE_BATCH_TASK,
+                Options.POST_BATCH_MODULE,
+                Options.POST_BATCH_TASK,
+                Options.MODULE_ROOT,
+                Options.MODULES_DATABASE,
+                Options.INSTALL,
+                Options.MAX_OPTS_FROM_MODULE,
+                Options.METADATA,
+                Options.METADATA_TO_PROCESS_MODULE
+            )));
+        builders.put(GROUP_EXECUTION, new OptionGroupBuilder(
+            GROUP_EXECUTION,
+            "Execution",
+            "Tune batching, thread usage, temp files, command-file control, and exit behavior.",
+            Arrays.asList(
+                Options.THREAD_COUNT,
+                Options.BATCH_SIZE,
+                Options.BATCH_URI_DELIM,
+                Options.FAIL_ON_ERROR,
+                Options.DISK_QUEUE,
+                Options.DISK_QUEUE_MAX_IN_MEMORY_SIZE,
+                Options.DISK_QUEUE_TEMP_DIR,
+                Options.TEMP_DIR,
+                Options.PRE_BATCH_MINIMUM_COUNT,
+                Options.POST_BATCH_MINIMUM_COUNT,
+                Options.COMMAND,
+                Options.COMMAND_FILE,
+                Options.COMMAND_FILE_POLL_INTERVAL,
+                Options.PRE_POST_BATCH_ALWAYS_EXECUTE,
+                Options.OPTIONS_FILE,
+                Options.OPTIONS_FILE_ENCODING,
+                Options.EXIT_CODE_NO_URIS,
+                Options.EXIT_CODE_IGNORED_ERRORS
+            )));
+        builders.put(GROUP_EXPORT, new OptionGroupBuilder(
+            GROUP_EXPORT,
+            "Export & Output",
+            "Configure file exports, post-processing, filenames, sorting, zipping, and error output.",
+            Arrays.asList(
+                Options.EXPORT_FILE_DIR,
+                Options.EXPORT_FILE_NAME,
+                Options.EXPORT_FILE_PART_EXT,
+                Options.EXPORT_FILE_REQUIRE_PROCESS_MODULE,
+                Options.EXPORT_FILE_URI_TO_PATH,
+                Options.EXPORT_FILE_TOP_CONTENT,
+                Options.EXPORT_FILE_BOTTOM_CONTENT,
+                Options.EXPORT_FILE_SORT,
+                Options.EXPORT_FILE_SORT_COMPARATOR,
+                Options.EXPORT_FILE_AS_ZIP,
+                Options.EXPORT_FILE_SPLIT_MAX_LINES,
+                Options.EXPORT_FILE_SPLIT_MAX_SIZE,
+                Options.ERROR_FILE_NAME
+            )));
+        builders.put(GROUP_MONITORING, new OptionGroupBuilder(
+            GROUP_MONITORING,
+            "Monitoring & Metrics",
+            "Configure the embedded Job Server, job naming, metrics persistence, and throughput reporting.",
+            Arrays.asList(
+                Options.JOB_NAME,
+                Options.JOB_SERVER_PORT,
+                Options.NUM_TPS_FOR_ETC,
+                Options.METRICS_DATABASE,
+                Options.METRICS_COLLECTIONS,
+                Options.METRICS_MODULE,
+                Options.METRICS_ROOT,
+                Options.METRICS_LOG_LEVEL,
+                Options.METRICS_NUM_FAILED_TRANSACTIONS,
+                Options.METRICS_NUM_SLOW_TRANSACTIONS,
+                Options.METRICS_SYNC_FREQUENCY
+            )));
+        builders.put(GROUP_RETRY, new OptionGroupBuilder(
+            GROUP_RETRY,
+            "Retry & Resilience",
+            "Control retry behavior for query and XCC connection failures.",
+            Arrays.asList(
+                Options.QUERY_RETRY_ERROR_CODES,
+                Options.QUERY_RETRY_ERROR_MESSAGE,
+                Options.QUERY_RETRY_INTERVAL,
+                Options.QUERY_RETRY_LIMIT,
+                Options.XCC_CONNECTION_RETRY_LIMIT,
+                Options.XCC_CONNECTION_RETRY_INTERVAL,
+                Options.XCC_CONNECTION_HOST_RETRY_LIMIT
+            )));
+        builders.put(GROUP_ADVANCED, new OptionGroupBuilder(
+            GROUP_ADVANCED,
+            "Advanced",
+            "Less common options are still surfaced here, and raw additional properties remain available for anything custom.",
+            Collections.emptyList()));
+
+        for (Field field : Options.class.getDeclaredFields()) {
+            OptionDefinition option = buildOptionDefinition(field);
+            if (option == null) {
+                continue;
+            }
+            String groupId = determineGroupId(field.getName());
+            OptionGroupBuilder builder = builders.get(groupId);
+            builder.options.add(option);
+            builder.registerSubgroup(option);
+        }
+
+        List<OptionGroup> groups = new ArrayList<OptionGroup>();
+        for (OptionGroupBuilder builder : builders.values()) {
+            if (builder.options.isEmpty()) {
+                continue;
+            }
+            Collections.sort(builder.options, builder.newComparator());
+            groups.add(builder.toOptionGroup());
+        }
+        return groups;
+    }
+
+    private OptionDefinition buildOptionDefinition(Field field) {
+        try {
+            if (!String.class.equals(field.getType()) || !Modifier.isPublic(field.getModifiers())) {
+                return null;
+            }
+            if (field.getAnnotation(Deprecated.class) != null || field.getName().endsWith("_LEGACY")) {
+                return null;
+            }
+            Usage usage = field.getAnnotation(Usage.class);
+            // if there's no usage annotation or description, we won't include the option in the builder metadata
+            if (usage == null || isBlank(usage.description())) {
+                return null;
+            }
+            String optionName = (String) field.get(null);
+            String subgroupTitle = determineSubgroupTitle(optionName);
+            String subgroupId = subgroupTitle.toLowerCase(Locale.ENGLISH).replaceAll("[^a-z0-9]+", "-");
+            return new OptionDefinition(optionName, optionDescriptions.get(optionName), determineInputType(optionName), PLACEHOLDERS.get(optionName), subgroupId, subgroupTitle);
+        } catch (IllegalAccessException ex) {
+            LOG.log(Level.WARNING, "Unable to build options builder metadata for field " + field.getName(), ex);
+            return null;
+        }
+    }
+
+    private String determineGroupId(String fieldName) {
+        if (fieldName.startsWith("XCC_") || fieldName.startsWith("CONTENT_SOURCE_") || "CONNECTION_POLICY".equals(fieldName)) {
+            return GROUP_CONNECTION;
+        }
+        if (fieldName.startsWith("SSL_") || fieldName.startsWith("PRIVATE_KEY_") || "DECRYPTER".equals(fieldName) || "JASYPT_PROPERTIES_FILE".equals(fieldName)) {
+            return GROUP_SECURITY;
+        }
+        if (fieldName.startsWith("URIS_") || fieldName.startsWith("LOADER_") || fieldName.startsWith("XML_") || "ZIP_FILE".equals(fieldName) || "COLLECTION_NAME".equals(fieldName)) {
+            return GROUP_INPUT;
+        }
+        if (fieldName.endsWith("_MODULE") || fieldName.endsWith("_TASK") || "MODULE_ROOT".equals(fieldName) || "MODULES_DATABASE".equals(fieldName)
+            || "INSTALL".equals(fieldName) || "MAX_OPTS_FROM_MODULE".equals(fieldName) || "METADATA".equals(fieldName)
+            || "METADATA_TO_PROCESS_MODULE".equals(fieldName)) {
+            return GROUP_PROCESSING;
+        }
+        if (fieldName.startsWith("EXPORT_") || "ERROR_FILE_NAME".equals(fieldName)) {
+            return GROUP_EXPORT;
+        }
+        if (fieldName.startsWith("METRICS_") || "JOB_NAME".equals(fieldName) || "JOB_SERVER_PORT".equals(fieldName) || "NUM_TPS_FOR_ETC".equals(fieldName)) {
+            return GROUP_MONITORING;
+        }
+        if (fieldName.startsWith("QUERY_RETRY_") || fieldName.startsWith("XCC_CONNECTION_RETRY_") || "XCC_CONNECTION_HOST_RETRY_LIMIT".equals(fieldName)) {
+            return GROUP_RETRY;
+        }
+        if (fieldName.startsWith("EXIT_CODE_") || fieldName.startsWith("BATCH_") || "FAIL_ON_ERROR".equals(fieldName)
+            || "THREAD_COUNT".equals(fieldName) || "TEMP_DIR".equals(fieldName) || fieldName.startsWith("DISK_QUEUE")
+            || fieldName.endsWith("_MINIMUM_COUNT") || fieldName.startsWith("COMMAND") || fieldName.startsWith("OPTIONS_FILE")
+            || "PRE_POST_BATCH_ALWAYS_EXECUTE".equals(fieldName)) {
+            return GROUP_EXECUTION;
+        }
+        return GROUP_ADVANCED;
+    }
+
+    private String determineInputType(String optionName) {
+        if (TEXTAREA_OPTIONS.contains(optionName)) {
+            return "textarea";
+        }
+        if (PASSWORD_OPTIONS.contains(optionName) || optionName.endsWith("-PASSWORD")) {
+            return "password";
+        }
+        if (BOOLEAN_OPTIONS.contains(optionName)) {
+            return "boolean";
+        }
+        if (NUMBER_OPTIONS.contains(optionName)) {
+            return "number";
+        }
+        return "text";
+    }
+
+    private String determineSubgroupTitle(String optionName) {
+        if (optionName.startsWith("EXPORT-FILE-")) {
+            return "EXPORT-FILE";
+        }
+        if (optionName.startsWith("XCC-CONNECTION-")) {
+            return "XCC-CONNECTION";
+        }
+        if (optionName.startsWith("QUERY-RETRY-")) {
+            return "QUERY-RETRY";
+        }
+        if (optionName.startsWith("COMMAND")) {
+            return "COMMAND";
+        }
+        if (optionName.startsWith("CONTENT-SOURCE-")) {
+            return "CONTENT-SOURCE";
+        }
+        if (optionName.startsWith("DISK-QUEUE-")) {
+            return "DISK-QUEUE";
+        }
+        if (optionName.startsWith("OPTIONS-FILE-")) {
+            return "OPTIONS-FILE";
+        }
+        if (optionName.startsWith("SSL-")) {
+            return "SSL";
+        }
+        if (optionName.startsWith("XCC-")) {
+            return "XCC";
+        }
+        if (optionName.startsWith("XML-")) {
+            return "XML";
+        }
+        if (optionName.startsWith("URIS-")) {
+            return "URIS";
+        }
+        if (optionName.startsWith("LOADER-")) {
+            return "LOADER";
+        }
+        if (optionName.startsWith("METRICS-")) {
+            return "METRICS";
+        }
+        if (optionName.startsWith("PRE-BATCH-")) {
+            return "PRE-BATCH";
+        }
+        if (optionName.startsWith("POST-BATCH-")) {
+            return "POST-BATCH";
+        }
+        if (optionName.startsWith("INIT-")) {
+            return "INIT";
+        }
+        if (optionName.startsWith("OPTIONS-FILE")) {
+            return "OPTIONS-FILE";
+        }
+        if (optionName.startsWith("PRIVATE-KEY-")) {
+            return "PRIVATE-KEY";
+        }
+        if (optionName.startsWith("PROCESS-")) {
+            return "PROCESS";
+        }
+        if (optionName.startsWith("MODULE-")) {
+            return "MODULE";
+        }
+        if (optionName.startsWith("BATCH-")) {
+            return "BATCH";
+        }
+        if (optionName.startsWith("EXIT-CODE-")) {
+            return "EXIT-CODE";
+        }
+        int index = optionName.indexOf('-');
+        if (index > 0) {
+            return optionName.substring(0, index);
+        }
+        return "General";
+    }
+
+    private Map<String, String> loadOptionDescriptions() {
+        Map<String, String> descriptions = new HashMap<>();
+        for (Field field : Options.class.getDeclaredFields()) {
+            try {
+                Usage usage = field.getAnnotation(Usage.class);
+                if (usage != null && String.class.equals(field.getType()) && Modifier.isPublic(field.getModifiers())) {
+                    descriptions.put((String) field.get(null), usage.description());
+                }
+            } catch (IllegalAccessException ex) {
+                LOG.log(Level.WARNING, "Unable to read option descriptions via reflection", ex);
+            }
+        }
+        return descriptions;
+    }
+
+    static String escapeJson(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        StringBuilder escaped = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '"':
+                    escaped.append("\\\"");
+                    break;
+                case '\\':
+                    escaped.append("\\\\");
+                    break;
+                case '\b':
+                    escaped.append("\\b");
+                    break;
+                case '\f':
+                    escaped.append("\\f");
+                    break;
+                case '\n':
+                    escaped.append("\\n");
+                    break;
+                case '\r':
+                    escaped.append("\\r");
+                    break;
+                case '\t':
+                    escaped.append("\\t");
+                    break;
+                default:
+                    if (ch <= 0x1F) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+            }
+        }
+        return escaped.toString();
+    }
+
+    interface JobLauncher {
+        JobLaunchResult launch(Properties properties) throws Exception;
+    }
+
+    static class JobLaunchResult {
+        private final String jobId;
+        private final String jobName;
+        private final String jobPath;
+
+        JobLaunchResult(String jobId, String jobName, String jobPath) {
+            this.jobId = jobId;
+            this.jobName = jobName;
+            this.jobPath = jobPath;
+        }
+
+        String toJson() {
+            StringBuilder json = new StringBuilder();
+            json.append('{');
+            json.append("\"jobId\":\"").append(escapeJson(jobId)).append("\",");
+            json.append("\"jobName\":\"").append(escapeJson(jobName == null ? "" : jobName)).append("\",");
+            json.append("\"jobPath\":\"").append(escapeJson(jobPath)).append("\"");
+            json.append('}');
+            return json.toString();
+        }
+    }
+
+    static class OptionGroup {
+        private final String id;
+        private final String title;
+        private final String description;
+        private final List<OptionSubgroup> subgroups;
+        private final List<OptionDefinition> options;
+
+        OptionGroup(String id, String title, String description, List<OptionSubgroup> subgroups, List<OptionDefinition> options) {
+            this.id = id;
+            this.title = title;
+            this.description = description;
+            this.subgroups = subgroups;
+            this.options = options;
+        }
+
+        String toJson() {
+            StringBuilder json = new StringBuilder();
+            json.append('{');
+            json.append("\"id\":\"").append(escapeJson(id)).append("\",");
+            json.append("\"title\":\"").append(escapeJson(title)).append("\",");
+            json.append("\"description\":\"").append(escapeJson(description)).append("\",");
+            json.append("\"subgroups\":[");
+            for (int i = 0; i < subgroups.size(); i++) {
+                if (i > 0) {
+                    json.append(',');
+                }
+                json.append(subgroups.get(i).toJson());
+            }
+            json.append("],");
+            json.append("\"options\":[");
+            for (int i = 0; i < options.size(); i++) {
+                if (i > 0) {
+                    json.append(',');
+                }
+                json.append(options.get(i).toJson());
+            }
+            json.append(']');
+            json.append('}');
+            return json.toString();
+        }
+
+        int getOptionCount() {
+            return options.size();
+        }
+    }
+
+    static class OptionDefinition {
+        private final String name;
+        private final String description;
+        private final String inputType;
+        private final String placeholder;
+        private final String subgroupId;
+        private final String subgroupTitle;
+
+        OptionDefinition(String name, String description, String inputType, String placeholder, String subgroupId, String subgroupTitle) {
+            this.name = name;
+            this.description = description == null ? "" : description;
+            this.inputType = inputType;
+            this.placeholder = placeholder == null ? "" : placeholder;
+            this.subgroupId = subgroupId;
+            this.subgroupTitle = subgroupTitle;
+        }
+
+        String toJson() {
+            StringBuilder json = new StringBuilder();
+            json.append('{');
+            json.append("\"name\":\"").append(escapeJson(name)).append("\",");
+            json.append("\"label\":\"").append(escapeJson(name)).append("\",");
+            json.append("\"description\":\"").append(escapeJson(description)).append("\",");
+            json.append("\"inputType\":\"").append(escapeJson(inputType)).append("\",");
+            json.append("\"subgroupId\":\"").append(escapeJson(subgroupId)).append("\",");
+            json.append("\"subgroupTitle\":\"").append(escapeJson(subgroupTitle)).append("\",");
+            json.append("\"placeholder\":\"").append(escapeJson(placeholder)).append("\"");
+            json.append('}');
+            return json.toString();
+        }
+    }
+
+    static class OptionSubgroup {
+        private final String id;
+        private final String title;
+
+        OptionSubgroup(String id, String title) {
+            this.id = id;
+            this.title = title;
+        }
+
+        String toJson() {
+            StringBuilder json = new StringBuilder();
+            json.append('{');
+            json.append("\"id\":\"").append(escapeJson(id)).append("\",");
+            json.append("\"title\":\"").append(escapeJson(title)).append("\"");
+            json.append('}');
+            return json.toString();
+        }
+    }
+
+    private static class OptionGroupBuilder {
+        private final String id;
+        private final String title;
+        private final String description;
+        private final Map<String, Integer> preferredOrder = new HashMap<>();
+        private final List<OptionDefinition> options = new ArrayList<>();
+        private final LinkedHashMap<String, OptionSubgroup> subgroups = new LinkedHashMap<String, OptionSubgroup>();
+
+        OptionGroupBuilder(String id, String title, String description, List<String> orderedOptionNames) {
+            this.id = id;
+            this.title = title;
+            this.description = description;
+            for (int i = 0; i < orderedOptionNames.size(); i++) {
+                preferredOrder.put(orderedOptionNames.get(i), Integer.valueOf(i));
+            }
+        }
+
+        java.util.Comparator<OptionDefinition> newComparator() {
+            return (left, right) -> {
+                int leftOrder = preferredOrder.containsKey(left.name) ? preferredOrder.get(left.name).intValue() : Integer.MAX_VALUE;
+                int rightOrder = preferredOrder.containsKey(right.name) ? preferredOrder.get(right.name).intValue() : Integer.MAX_VALUE;
+                if (leftOrder != rightOrder) {
+                    return leftOrder < rightOrder ? -1 : 1;
+                }
+                return left.name.compareTo(right.name);
+            };
+        }
+
+        OptionGroup toOptionGroup() {
+            return new OptionGroup(id, title, description, new ArrayList<>(subgroups.values()), options);
+        }
+
+        void registerSubgroup(OptionDefinition option) {
+            if (!subgroups.containsKey(option.subgroupId)) {
+                subgroups.put(option.subgroupId, new OptionSubgroup(option.subgroupId, option.subgroupTitle));
+            }
+        }
+    }
+
+    private static Set<String> setOf(String... values) {
+        return new HashSet<>(Arrays.asList(values));
+    }
+}

--- a/src/main/java/com/marklogic/developer/corb/JobServer.java
+++ b/src/main/java/com/marklogic/developer/corb/JobServer.java
@@ -30,7 +30,7 @@ import javax.xml.transform.TransformerFactory;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
 import java.util.*;
@@ -40,6 +40,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static com.marklogic.developer.corb.Options.JOB_SERVER_PORT;
+import static com.marklogic.developer.corb.util.StringUtils.parsePortRanges;
 import static java.util.logging.Level.INFO;
 
 /**
@@ -215,6 +217,11 @@ public class JobServer {
     private Templates jobStatsToJsonTemplates;
 
     /**
+     * Handler for Job Server options-builder endpoints.
+     */
+    private final JobBuilderHandler jobBuilderHandler;
+
+    /**
      * Flag indicating whether the server has received any HTTP requests.
      * <p>
      * Used to determine shutdown behavior - if requests have been received, the server
@@ -223,6 +230,24 @@ public class JobServer {
      * </p>
      */
     private boolean hasReceivedRequests = false;
+
+    /**
+     * Main method to start the JobServer.
+     * <p>
+     * The server will attempt to bind to the first available port from the specified
+     * range (defaulting to 8003-9999 if not provided). Once started, it will log
+     * access URLs for monitoring and managing jobs.
+     * </p>
+     *
+     * @param args command-line arguments (optional port range)
+     * @throws IOException if the server fails to start or bind to a port
+     */
+    public static void main(String[] args) throws IOException {
+        String portOption = args != null && args.length > 0 ? args[0] : System.getProperty(JOB_SERVER_PORT);
+        String jobServerPortRange = portOption != null ? portOption : "8003-9999";
+        Set<Integer> jobServerPorts = new LinkedHashSet<>(parsePortRanges(jobServerPortRange));
+        JobServer.create(jobServerPorts, null).start();
+    }
 
     /**
      * Creates a JobServer instance bound to the specified port.
@@ -273,6 +298,7 @@ public class JobServer {
         server = HttpServer.create();
         bindFirstAvailablePort(portCandidates, requestQueueSize);
         setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
+        this.jobBuilderHandler = new JobBuilderHandler(this);
         addManager(manager);
 
         createContext(HTTP_RESOURCE_PATH, this::handleRequest);
@@ -294,7 +320,13 @@ public class JobServer {
         String querystring = httpExchange.getRequestURI().getQuery();
         Map<String,String> params = JobServicesHandler.querystringToMap(querystring);
 
-        if (METRICS_PATH.equals(path) || hasParameter(params, JobServicesHandler.PARAM_FORMAT)) {
+        if (JobBuilderHandler.canHandle(path)) {
+            try {
+                jobBuilderHandler.handle(httpExchange);
+            } catch (IOException ex) {
+                LOG.log(Level.WARNING, "Unable to handle options builder request", ex);
+            }
+        } else if (METRICS_PATH.equals(path) || hasParameter(params, JobServicesHandler.PARAM_FORMAT)) {
             alowXSS(httpExchange);
 
             String contentType = determineContentType(params);
@@ -326,7 +358,7 @@ public class JobServer {
 
             try (OutputStream out = httpExchange.getResponseBody()) {
                 httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length());
-                out.write(response.toString().getBytes(Charset.forName("UTF-8")));
+                out.write(response.toString().getBytes(StandardCharsets.UTF_8));
                 out.flush();
             } catch (IOException ex) {
                 LOG.log(Level.WARNING, "Unable to list jobs", ex);

--- a/src/main/java/com/marklogic/developer/corb/Options.java
+++ b/src/main/java/com/marklogic/developer/corb/Options.java
@@ -164,7 +164,7 @@ public final class Options {
      *
      * @since 2.4.0
      */
-    @Usage(description = "Connection policy for allocating connections to tasks while using DefaultConnectionPool. Acceptable values ROUNBD-ROBIN, RANDOM and LOAD. Default is ROUND-ROBIN")
+    @Usage(description = "Connection policy for allocating connections to tasks while using DefaultConnectionPool. Acceptable values ROUND-ROBIN, RANDOM and LOAD. Default is ROUND-ROBIN")
     public static final String CONNECTION_POLICY = "CONNECTION-POLICY";
 
     /**

--- a/src/main/resources/web/css/dashboard.css
+++ b/src/main/resources/web/css/dashboard.css
@@ -1,3 +1,7 @@
+[x-cloak] {
+    display: none !important;
+}
+
 body {
     font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
     margin: 2rem;
@@ -7,8 +11,36 @@ h1, h2, h3, h4 {
     margin: 0.25rem 0 0.75rem;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4 {
     border-bottom: 1px solid black;
+}
+
+h1 { border-bottom: none; margin-bottom: 0; }
+
+nav {
+    overflow: hidden;
+    border: 1px solid #ccc;
+    background-color: #f1f1f1;
+    display: flex;
+}
+
+nav button {
+    background-color: inherit;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    margin-left: 0px;
+    transition: 0.3s;
+    font-size: 17px;
+}
+
+nav button:hover {
+    background-color: #ddd;
+}
+
+nav button.active {
+    background-color: #ccc;
 }
 
 .main .page-header {
@@ -109,6 +141,11 @@ tr:nth-child(odd) {
     background: #dc2626;
 }
 
+.btn.selected {
+    background: #1d4ed8;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
 .input {
     padding: 0.4rem 0.5rem;
     border: 1px solid #d1d5db;
@@ -124,7 +161,216 @@ progress {
     width: 100%;
 }
 
-/* Toasts */
+.builder-panel {
+    border: 1px solid #d1d5db;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    background: #f8fafc;
+}
+
+.builder-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.builder-heading {
+    flex: 1 1 auto;
+}
+
+.builder-subtitle {
+    margin: 0;
+    max-width: 54rem;
+    color: #374151;
+}
+
+.builder-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.builder-search {
+    min-width: 14rem;
+}
+
+.builder-file-name {
+    min-width: 15rem;
+}
+
+.builder-collapse-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.builder-collapse-icon {
+    width: 0.95rem;
+    height: 0.95rem;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    fill: none;
+    transition: transform 0.15s ease-in-out;
+    transform: rotate(0deg);
+}
+
+.builder-collapse-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+.builder-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.builder-tab {
+    appearance: none;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    background: white;
+    padding: 0.45rem 0.8rem;
+    cursor: pointer;
+}
+
+.builder-tab.active {
+    background: #2563eb;
+    color: white;
+    border-color: #2563eb;
+}
+
+.builder-group {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+.builder-group-header {
+    margin-bottom: 1rem;
+}
+
+.builder-group-description {
+    margin: 0;
+    color: #4b5563;
+}
+
+.builder-summary {
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+    color: #374151;
+}
+
+.builder-toggle-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    background: #eff6ff;
+}
+
+.builder-toggle-label {
+    font-weight: 600;
+}
+
+.builder-toggle-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.builder-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+}
+
+.builder-subgroups {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.builder-subgroup {
+    border-top: 1px solid #e5e7eb;
+    padding-top: 1rem;
+}
+
+.builder-subgroup:first-child {
+    border-top: none;
+    padding-top: 0;
+}
+
+.builder-subgroup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.builder-subgroup-header h4 {
+    margin: 0;
+}
+
+.builder-subgroup-count {
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+.builder-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.builder-label {
+    font-weight: 600;
+}
+
+.builder-label.interactive {
+    cursor: pointer;
+}
+
+.builder-help {
+    font-size: 0.875rem;
+    line-height: 1.35;
+    color: #4b5563;
+}
+
+.builder-textarea {
+    min-height: 6rem;
+    width: 100%;
+    resize: vertical;
+}
+
+.builder-additional-properties {
+    margin-top: 1rem;
+}
+
+.builder-empty-state {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border: 1px dashed #cbd5e1;
+    border-radius: 0.5rem;
+    color: #475569;
+    background: #f8fafc;
+}
+
+.builder-preview {
+    width: 100%;
+    min-height: 14rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    cursor: text;              /* Keeps cursor as text for highlighting/copying */
+}
+
 .toast-wrap {
     position: fixed;
     right: 1rem;
@@ -165,7 +411,6 @@ progress {
     opacity: 1;
 }
 
-/* Spinner (tiny) */
 .spinner {
     width: 14px;
     height: 14px;

--- a/src/main/resources/web/dashboard.html
+++ b/src/main/resources/web/dashboard.html
@@ -14,8 +14,159 @@
 </head>
 <body>
 <main x-data="dashboard()">
-    <h1>Job Dashboard</h1>
-    <div class="section">
+    <h1>CoRB</h1>
+
+    <nav>
+        <button @click="currentTab = 1" :class=" {active: currentTab==1}">Jobs Dashboard</button>
+        <button @click="currentTab = 2" :class="{active: currentTab==2}">Options Builder</button>
+    </nav>
+
+    <div class="section builder-panel" x-cloak x-show="currentTab === 2">
+        <div class="builder-header">
+            <div class="builder-heading">
+                <h2 class="page-header">Options Builder</h2>
+                <p class="builder-subtitle">Build a CoRB job configuration, download the resulting properties file, or run the job directly from here.</p>
+            </div>
+            <div class="builder-actions">
+                <input class="input builder-file-name" type="text" x-model="builder.downloadFileName" placeholder="corb-job.properties" />
+                <button class="btn secondary" :disabled="builder.loadingMetadata || builder.downloading" @click="downloadBuilderProperties()">
+                    <span x-text="builder.downloading ? 'Preparing...' : 'Download Options File'"></span>
+                </button>
+                <button class="btn" :disabled="builder.loadingMetadata || builder.running" @click="runBuilderJob()">
+                    <span x-text="builder.running ? 'Starting...' : 'Run job'"></span>
+                </button>
+            </div>
+        </div>
+
+        <div id="options-builder-content" x-show="!builder.collapsed">
+
+            <div x-show="builder.loadingMetadata" class="hint">Loading options builder metadata...</div>
+            <div x-show="builder.error" class="hint" x-text="builder.error"></div>
+
+            <template x-if="!builder.loadingMetadata && builder.groups.length">
+                <div>
+
+                <div class="builder-tabs" role="tablist" aria-label="Options builder groups">
+                    <template x-for="group in builder.groups" :key="group.id">
+                        <button type="button"
+                                class="builder-tab"
+                                :class="{ active: builder.activeGroupId === group.id }"
+                                @click="builder.activeGroupId = group.id"
+                                x-text="`${group.title} (${builderGroupOptionCount(group)})`"></button>
+                    </template>
+                    <input class="input builder-search" type="text" x-model="builder.searchTerm" placeholder="Search options" />
+
+                </div>
+
+                <div class="builder-summary">
+                    <span x-text="`${builderVisibleOptionCount()} of ${builderTotalOptionCount()} options shown`"></span>
+                </div>
+
+                <template x-for="group in builder.groups" :key="group.id + '-panel'">
+                    <section class="builder-group" x-show="builder.activeGroupId === group.id">
+                        <div class="builder-group-header">
+                            <h3 x-text="group.title"></h3>
+                            <p class="builder-group-description" x-text="group.description"></p>
+                        </div>
+
+                        <template x-if="group.id === 'connection'">
+                            <div class="builder-toggle-row">
+                                <span class="builder-toggle-label">XCC Connection</span>
+                                <div class="builder-toggle-buttons">
+                                    <button type="button" class="btn secondary" :class="{ selected: builder.connectionMode === 'uri' }" @click="setConnectionMode('uri')">URI</button>
+                                    <button type="button" class="btn secondary" :class="{ selected: builder.connectionMode === 'fields' }" @click="setConnectionMode('fields')">Individual Fields</button>
+                                </div>
+                            </div>
+                        </template>
+
+                        <div class="builder-subgroups">
+                            <template x-for="subgroup in visibleBuilderSubgroups(group)" :key="`${group.id}-${subgroup.id}`">
+                                <section class="builder-subgroup">
+                                    <div class="builder-subgroup-header">
+                                        <h4 x-text="subgroup.title"></h4>
+                                        <span class="builder-subgroup-count" x-text="`${visibleBuilderOptionsForSubgroup(group, subgroup).length} option(s)`"></span>
+                                    </div>
+
+                                    <div class="builder-form-grid">
+                                        <template x-for="option in visibleBuilderOptionsForSubgroup(group, subgroup)" :key="option.name">
+                                            <div class="builder-field">
+                                                <label class="builder-label"
+                                                       :class="{ interactive: hasBuilderDescription(option) }"
+                                                       :for="builderFieldId(option.name)"
+                                                       :title="option.description || ''"
+                                                       :aria-expanded="isBuilderDescriptionVisible(option.name).toString()"
+                                                       :aria-controls="builderDescriptionId(option.name)"
+                                                       :tabindex="hasBuilderDescription(option) ? '0' : null"
+                                                       @click.prevent="hasBuilderDescription(option) && toggleBuilderDescription(option.name)"
+                                                       @keydown.enter.prevent="hasBuilderDescription(option) && toggleBuilderDescription(option.name)"
+                                                       @keydown.space.prevent="hasBuilderDescription(option) && toggleBuilderDescription(option.name)"
+                                                       x-text="option.label"></label>
+
+                                                <template x-if="option.inputType === 'textarea'">
+                                                    <textarea class="input builder-textarea"
+                                                              :id="builderFieldId(option.name)"
+                                                              :placeholder="option.placeholder"
+                                                              x-model="builder.values[option.name]"></textarea>
+                                                </template>
+
+                                                <template x-if="option.inputType === 'boolean'">
+                                                    <select class="input"
+                                                            :id="builderFieldId(option.name)"
+                                                            x-model="builder.values[option.name]">
+                                                        <option value="">Not set</option>
+                                                        <option value="true">true</option>
+                                                        <option value="false">false</option>
+                                                    </select>
+                                                </template>
+
+                                                <template x-if="option.inputType !== 'textarea' && option.inputType !== 'boolean'">
+                                                    <input class="input"
+                                                           :id="builderFieldId(option.name)"
+                                                           :type="option.inputType"
+                                                           :placeholder="option.placeholder"
+                                                           x-model="builder.values[option.name]" />
+                                                </template>
+
+                                                <div class="builder-help"
+                                                     x-cloak
+                                                     x-show="isBuilderDescriptionVisible(option.name)"
+                                                     :id="builderDescriptionId(option.name)"
+                                                     x-text="option.description"></div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </section>
+                            </template>
+                        </div>
+
+                        <div class="builder-empty-state" x-show="visibleBuilderOptions(group).length === 0">
+                            No options in this section match the current search or connection mode.
+                        </div>
+
+                        <template x-if="group.id === 'advanced'">
+                            <div class="builder-field builder-additional-properties">
+                                <label class="builder-label" for="builder-additional-properties">Additional properties</label>
+                                <textarea id="builder-additional-properties"
+                                          class="input builder-textarea"
+                                          placeholder="CUSTOM-OPTION=value"
+                                          x-model="builder.additionalProperties"></textarea>
+                                <div class="builder-help">Use this for options that are not modeled in the form yet, or for custom task/module properties.</div>
+                            </div>
+                        </template>
+                    </section>
+                </template>
+
+                <div class="section">
+                    <h3>Generated options preview</h3>
+                    <textarea class="input builder-preview" readonly :value="builderPropertiesPreview()"></textarea>
+                </div>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <div class="section builder-panel" x-show="currentTab === 1">
+        <h2 class="page-header">Monitor Jobs</h2>
         <table>
             <thead>
             <tr>
@@ -62,7 +213,6 @@
                                     @click="togglePause(i)"
                                     x-text="i.paused ? 'Resume' : 'Pause'">
                             </button>
-                            <!-- lightweight spinner / pending dot -->
                             <span x-show="isPending(i.id)" class="spinner" aria-label="Pending"></span>
                         </div>
                     </td>
@@ -76,7 +226,7 @@
         </table>
     </div>
 
-    <div class="section">
+    <div class="section builder-panel" x-show="currentTab === 1">
         <h3 id="monitorHosts">Monitor Hosts</h3>
         <div class="outer-grid">
             <div class="row" style="margin-bottom:0.75rem;">
@@ -109,7 +259,6 @@
         </div>
     </div>
 
-    <!-- Toasts -->
     <div aria-live="polite" class="toast-wrap">
         <template x-for="t in toasts" :key="t.id">
             <div class="toast" :class="t.type" x-text="t.message" @click="removeToast(t.id)"></div>

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -19,7 +19,7 @@
     <div class="section">
         <div>
             <span class="stat success">Success (<span x-text="successPercent"></span>%)</span>
-            <span class="stat fail">Failed (<span x-text="failedPercent"></span>%)</span>
+            <span class="stat fail" x-show="failedPercent > 0">Failed (<span x-text="failedPercent"></span>%)</span>
         </div>
         <div>
             <progress :max="job.totalNumberOfTasks ?? 0" :value="(job.numberOfSucceededTasks ?? 0) + (job.numberOfFailedTasks ?? 0)" :title="job.numberOfSucceededTasks + job.numberOfFailedTasks"></progress>

--- a/src/main/resources/web/js/corbApp.js
+++ b/src/main/resources/web/js/corbApp.js
@@ -1,8 +1,5 @@
 "use strict";
 
-// ----------------------
-// Shared utilities
-// ----------------------
 export function msToTime(ms) {
     if (!Number.isFinite(ms) || ms < 0) { return "00:00:00"; }
     const totalSeconds = Math.floor(ms / 1000);
@@ -19,7 +16,6 @@ function withTimeout(ms = 8000) {
 }
 
 function jobBaseUrl(job) {
-    // job: { id, host, port }
     const origin = `${location.protocol}//${job.host}${job.port ? `:${job.port}` : ""}`;
     return new URL(`/${encodeURIComponent(job.id)}`, origin);
 }
@@ -28,10 +24,13 @@ function metricsUrl(host, port, { concise = true } = {}) {
     const url = new URL(`http://${host}:${port}/`);
     url.searchParams.set("format", "json");
     if (concise) {
-        // Presence-only parameter (serialized as `concise=`); server should treat presence as true
         url.searchParams.append("concise", "");
     }
     return url;
+}
+
+function builderUrl(path) {
+    return new URL(path, location.origin);
 }
 
 async function fetchJson(url, { signal } = {}) {
@@ -44,7 +43,6 @@ async function fetchJson(url, { signal } = {}) {
         }
         return await res.json();
     } catch (e) {
-        // Map network/abort failures to synthetic -1 to retain legacy handling
         if (e && typeof e.status === "undefined") {
             e.status = -1;
         }
@@ -52,11 +50,9 @@ async function fetchJson(url, { signal } = {}) {
     }
 }
 
-// POST commands via QUERY STRING (server requires query params)
 async function postQuery(job, params, { signal } = {}) {
     const url = jobBaseUrl(job);
     url.searchParams.set("format", "json");
-    // append provided params as query string
     for (const [k, v] of Object.entries(params)) {
         if (typeof v === "undefined" || v === null) { continue; }
         url.searchParams.set(k, String(v));
@@ -77,6 +73,29 @@ async function postQuery(job, params, { signal } = {}) {
     }
 }
 
+async function postForm(url, params, { signal } = {}) {
+    try {
+        const res = await fetch(url.toString(), {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
+            body: params.toString(),
+            signal,
+        });
+        if (!res.ok) {
+            const message = await res.text();
+            const err = new Error(message || `POST ${url} failed with ${res.status}`);
+            err.status = res.status;
+            throw err;
+        }
+        return res;
+    } catch (e) {
+        if (e && typeof e.status === "undefined") {
+            e.status = -1;
+        }
+        throw e;
+    }
+}
+
 function isDone(job) {
     const total = job?.totalNumberOfTasks ?? 0;
     const progressed = (job?.numberOfSucceededTasks ?? 0) + (job?.numberOfFailedTasks ?? 0);
@@ -88,10 +107,9 @@ function isRunning(job) {
     return !isDone(job) && (job?.currentThreadCount ?? 0) !== 0;
 }
 
-// Minimal toast manager
 function toastMixin() {
     return {
-        toasts: [], // { id, message, type }
+        toasts: [],
         _toastId: 0,
         pushToast(message, type = "error", duration = 4000) {
             const id = ++this._toastId;
@@ -105,17 +123,51 @@ function toastMixin() {
     };
 }
 
-// ----------------------
-// Single-Job View Component
-// ----------------------
+function parseContentDispositionFilename(headerValue) {
+    if (!headerValue) {
+        return null;
+    }
+    const match = headerValue.match(/filename="?([^";]+)"?/i);
+    return match ? match[1] : null;
+}
+
+function escapePropertiesValue(value) {
+    if (value === null || typeof value === "undefined") {
+        return "";
+    }
+    let text = String(value)
+        .replace(/\\/g, "\\\\")
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t");
+    if (text.startsWith(" ")) {
+        text = `\\${text}`;
+    }
+    return text;
+}
+
+const CONNECTION_COMPONENT_OPTIONS = new Set([
+    "XCC-PROTOCOL",
+    "XCC-HOSTNAME",
+    "XCC-PORT",
+    "XCC-DBNAME",
+    "XCC-USERNAME",
+    "XCC-PASSWORD",
+    "XCC-BASE-PATH",
+    "XCC-API-KEY",
+    "XCC-OAUTH-TOKEN",
+    "XCC-GRANT-TYPE",
+    "XCC-TOKEN-DURATION",
+    "XCC-TOKEN-ENDPOINT"
+]);
+
 export function jobStatus({ pollingMs = 3000 } = {}) {
     return {
         ...toastMixin(),
         job: { currentThreadCount: 0 },
         timers: new Map(),
         error: null,
-        pending: false, // for pause/resume only; thread input remains enabled
-        // First load retrieves full payload (with options), subsequent polls use concise
+        pending: false,
         _firstLoad: true,
 
         get totalNumberOfTasks() { return this.job?.totalNumberOfTasks ?? 0; },
@@ -152,7 +204,6 @@ export function jobStatus({ pollingMs = 3000 } = {}) {
             const url = new URL(location.href);
             url.searchParams.set("format", "json");
             if (!this._firstLoad) {
-                // Compact payload for polling cycles
                 url.searchParams.append("concise", "");
             }
             return url;
@@ -168,7 +219,6 @@ export function jobStatus({ pollingMs = 3000 } = {}) {
                     this.stopTimer(url.toString());
                 }
             } catch (e) {
-                // Handle 404 or synthetic -1 (no backend)
                 if (e.status === 404 || e.status === -1) {
                     this.stopTimer(url.toString());
                 }
@@ -217,7 +267,7 @@ export function jobStatus({ pollingMs = 3000 } = {}) {
         updateThreadCount(job, threads) {
             const n = Number(threads);
             if (!Number.isFinite(n) || n < 1) { return; }
-            this.job.currentThreadCount = n; // optimistic
+            this.job.currentThreadCount = n;
             if (this._threadTimer) { clearTimeout(this._threadTimer); }
             this._threadTimer = setTimeout(() => this.commitThreadCount(job, n), 300);
         },
@@ -232,7 +282,6 @@ export function jobStatus({ pollingMs = 3000 } = {}) {
                 console.warn(e);
                 this.error = e.message;
                 this.pushToast(`Thread update failed (${e.status === -1 ? jobBaseUrl(job) + " unavailable" : e.status})`);
-                // Optional: re-fetch to reconcile optimistic update
                 await this.refresh();
             } finally {
                 done();
@@ -243,23 +292,37 @@ export function jobStatus({ pollingMs = 3000 } = {}) {
     };
 }
 
-// ----------------------
-// Dashboard (Multi-Job) Component
-// ----------------------
 export function dashboard({ pollingMs = 2000 } = {}) {
     const HOST_RE = /^(?:\[(?:[A-Fa-f0-9:]+)\]|(?:[A-Za-z0-9-.]+))$/;
     return {
         ...toastMixin(),
-        monitorHosts: [], // [{ host: string, ports: string }]
-        timers: new Map(), // metricsUrl -> intervalId
+        monitorHosts: [],
+        timers: new Map(),
         jobs: [],
         error: null,
-        pendingJobs: new Set(), // job.id values for which a command is in-flight
+        pendingJobs: new Set(),
+        currentTab: 1,
+        builder: {
+            groups: [],
+            values: {},
+            expandedDescriptions: {},
+            additionalProperties: "",
+            connectionMode: "uri",
+            activeGroupId: "connection",
+            searchTerm: "",
+            collapsed: false,
+            loadingMetadata: false,
+            running: false,
+            downloading: false,
+            error: null,
+            downloadFileName: "corb-job.properties",
+        },
 
         init() {
             try {
                 this.addMonitor({ host: location.hostname, ports: location.port });
             } catch {}
+            this.loadBuilderMetadata();
             addEventListener("beforeunload", () => this.destroy());
         },
 
@@ -297,7 +360,7 @@ export function dashboard({ pollingMs = 2000 } = {}) {
                     const u = new URL(h);
                     h = u.hostname;
                 } else if (!HOST_RE.test(h)) {
-                    return out; // invalid host token
+                    return out;
                 }
             } catch {
                 return out;
@@ -404,7 +467,7 @@ export function dashboard({ pollingMs = 2000 } = {}) {
         updateThreadCount(job, threads) {
             const n = Number(threads);
             if (!Number.isFinite(n) || n < 1) { return; }
-            job.currentThreadCount = n; // optimistic
+            job.currentThreadCount = n;
             const existing = this._threadTimers.get(job.id);
             if (existing) { clearTimeout(existing); }
             const to = setTimeout(() => this.commitThreadCount(job, n), 300);
@@ -431,6 +494,198 @@ export function dashboard({ pollingMs = 2000 } = {}) {
         openJob(job) {
             const url = jobBaseUrl(job);
             window.open(url.toString(), "_blank");
-        }
+        },
+
+        async loadBuilderMetadata() {
+            this.builder.loadingMetadata = true;
+            this.builder.error = null;
+            const { signal, done } = withTimeout(15000);
+            try {
+                const data = await fetchJson(builderUrl("/builder/metadata"), { signal });
+                this.builder.groups = [].concat(data.groups ?? []);
+                this.builder.activeGroupId = this.builder.groups.length ? this.builder.groups[0].id : "connection";
+                const values = {};
+                this.builder.groups.forEach((group) => {
+                    group.options.forEach((option) => {
+                        if (!Object.prototype.hasOwnProperty.call(values, option.name)) {
+                            values[option.name] = "";
+                        }
+                    });
+                });
+                this.builder.values = Object.assign(values, this.builder.values);
+                this.builder.expandedDescriptions = Object.assign({}, this.builder.expandedDescriptions);
+            } catch (e) {
+                console.warn(e);
+                this.builder.error = e.message;
+                this.pushToast(`Options builder error: ${e.message}`);
+            } finally {
+                this.builder.loadingMetadata = false;
+                done();
+            }
+        },
+
+        builderFieldId(name) {
+            return `builder-${String(name).toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+        },
+
+        builderDescriptionId(name) {
+            return `${this.builderFieldId(name)}-description`;
+        },
+
+        setConnectionMode(mode) {
+            this.builder.connectionMode = mode;
+        },
+
+        toggleBuilderCollapsed() {
+            this.builder.collapsed = !this.builder.collapsed;
+        },
+
+        visibleBuilderOptions(group) {
+            return (group?.options ?? []).filter((option) => this.shouldShowBuilderOption(option) && this.matchesBuilderSearch(option));
+        },
+
+        hasBuilderDescription(option) {
+            return String(option?.description ?? "").trim() !== "";
+        },
+
+        toggleBuilderDescription(name) {
+            const current = !!this.builder.expandedDescriptions[name];
+            this.builder.expandedDescriptions = Object.assign({}, this.builder.expandedDescriptions, { [name]: !current });
+        },
+
+        isBuilderDescriptionVisible(name) {
+            return !!this.builder.expandedDescriptions[name];
+        },
+
+        visibleBuilderSubgroups(group) {
+            return (group?.subgroups ?? []).filter((subgroup) => this.visibleBuilderOptionsForSubgroup(group, subgroup).length > 0);
+        },
+
+        visibleBuilderOptionsForSubgroup(group, subgroup) {
+            return this.visibleBuilderOptions(group).filter((option) => option.subgroupId === subgroup.id);
+        },
+
+        matchesBuilderSearch(option) {
+            const term = this.builder.searchTerm.trim().toLowerCase();
+            if (!term) {
+                return true;
+            }
+            return [option.name, option.label, option.description]
+                .some((value) => String(value ?? "").toLowerCase().includes(term));
+        },
+
+        shouldShowBuilderOption(option) {
+            if (option.name === "XCC-CONNECTION-URI") {
+                return this.builder.connectionMode === "uri";
+            }
+            if (CONNECTION_COMPONENT_OPTIONS.has(option.name)) {
+                return this.builder.connectionMode === "fields";
+            }
+            return true;
+        },
+
+        builderGroupOptionCount(group) {
+            return this.visibleBuilderOptions(group).length;
+        },
+
+        builderTotalOptionCount() {
+            return this.builder.groups.reduce((total, group) => total + ((group?.options ?? []).length), 0);
+        },
+
+        builderVisibleOptionCount() {
+            return this.builder.groups.reduce((total, group) => total + this.visibleBuilderOptions(group).length, 0);
+        },
+
+        serializeBuilderPayload(includeDownloadFileName = true) {
+            const params = new URLSearchParams();
+            this.builder.groups.forEach((group) => {
+                (group.options ?? []).forEach((option) => {
+                    if (!this.shouldShowBuilderOption(option)) {
+                        return;
+                    }
+                    const value = this.builder.values[option.name];
+                    if (value === null || typeof value === "undefined") {
+                        return;
+                    }
+                    const normalized = String(value).trim();
+                    if (normalized === "") {
+                        return;
+                    }
+                    params.set(option.name, normalized);
+                });
+            });
+            if (this.builder.additionalProperties.trim() !== "") {
+                params.set("builder.additionalProperties", this.builder.additionalProperties);
+            }
+            if (includeDownloadFileName && this.builder.downloadFileName.trim() !== "") {
+                params.set("builder.downloadFileName", this.builder.downloadFileName.trim());
+            }
+            return params;
+        },
+
+        builderPropertiesPreview() {
+            const lines = [];
+            for (const [name, value] of this.serializeBuilderPayload(false).entries()) {
+                if (name.startsWith("builder.")) {
+                    continue;
+                }
+                lines.push(`${name}=${escapePropertiesValue(value)}`);
+            }
+            if (this.builder.additionalProperties.trim() !== "") {
+                if (lines.length) {
+                    lines.push("");
+                }
+                lines.push(this.builder.additionalProperties.trim());
+            }
+            return lines.join("\n");
+        },
+
+        async downloadBuilderProperties() {
+            this.builder.downloading = true;
+            const { signal, done } = withTimeout(15000);
+            try {
+                const response = await postForm(builderUrl("/builder/properties"), this.serializeBuilderPayload(true), { signal });
+                const blob = await response.blob();
+                const contentDisposition = response.headers.get("Content-Disposition");
+                const filename = parseContentDispositionFilename(contentDisposition) || this.builder.downloadFileName || "corb-job.properties";
+                const blobUrl = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = blobUrl;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(blobUrl);
+                this.pushToast(`Downloaded ${filename}`, "success");
+            } catch (e) {
+                console.warn(e);
+                this.builder.error = e.message;
+                this.pushToast(`Download failed: ${e.message}`);
+            } finally {
+                this.builder.downloading = false;
+                done();
+            }
+        },
+
+        async runBuilderJob() {
+            this.builder.running = true;
+            const { signal, done } = withTimeout(15000);
+            try {
+                const response = await postForm(builderUrl("/builder/jobs"), this.serializeBuilderPayload(false), { signal });
+                const data = await response.json();
+                await this.metricsRefresh(metricsUrl(location.hostname, location.port, { concise: true }));
+                this.pushToast(`Started job ${data.jobId}`, "success");
+                if (data.jobPath) {
+                    window.open(new URL(data.jobPath, location.origin).toString(), "_blank");
+                }
+            } catch (e) {
+                console.warn(e);
+                this.builder.error = e.message;
+                this.pushToast(`Run failed: ${e.message}`);
+            } finally {
+                this.builder.running = false;
+                done();
+            }
+        },
     };
 }

--- a/src/test/java/com/marklogic/developer/corb/JobBuilderHandlerTest.java
+++ b/src/test/java/com/marklogic/developer/corb/JobBuilderHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * * Copyright (c) 2004-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * *
+ * * The use of the Apache License does not indicate that this project is
+ * * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JobBuilderHandlerTest {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    @Test
+    void handlePropertiesRequestDecodesFormValues() throws Exception {
+        Headers headers = new Headers();
+        HttpExchange exchange = mock(HttpExchange.class);
+        when(exchange.getRequestURI()).thenReturn(URI.create(JobBuilderHandler.BUILDER_PROPERTIES_PATH));
+        when(exchange.getRequestMethod()).thenReturn("POST");
+        when(exchange.getResponseHeaders()).thenReturn(headers);
+        when(exchange.getRequestBody()).thenReturn(new ByteArrayInputStream((Options.PROCESS_MODULE + "=%2Fext%2Fprocess.xqy&" + JobBuilderService.PARAM_DOWNLOAD_FILE_NAME + "=nightly%20run").getBytes(UTF_8)));
+        OutputStream out = new ByteArrayOutputStream();
+        when(exchange.getResponseBody()).thenReturn(out);
+
+        JobBuilderService service = mock(JobBuilderService.class);
+        when(service.buildPropertiesFile(anyMap())).thenReturn(Options.PROCESS_MODULE + "=/ext/process.xqy\n");
+        when(service.resolveDownloadFilename(anyMap())).thenReturn("nightly-run.properties");
+
+        JobBuilderHandler handler = new JobBuilderHandler(service);
+        handler.handle(exchange);
+
+        verify(service).buildPropertiesFile(org.mockito.ArgumentMatchers.argThat(params -> "/ext/process.xqy".equals(params.get(Options.PROCESS_MODULE))));
+        assertTrue(headers.getFirst("Content-Disposition").contains("nightly-run.properties"));
+        assertTrue(out.toString().contains(Options.PROCESS_MODULE + "=/ext/process.xqy"));
+    }
+
+    @Test
+    void handleJobLaunchReturnsLauncherPayload() throws Exception {
+        Headers headers = new Headers();
+        HttpExchange exchange = mock(HttpExchange.class);
+        when(exchange.getRequestURI()).thenReturn(URI.create(JobBuilderHandler.BUILDER_JOBS_PATH));
+        when(exchange.getRequestMethod()).thenReturn("POST");
+        when(exchange.getResponseHeaders()).thenReturn(headers);
+        when(exchange.getRequestBody()).thenReturn(new ByteArrayInputStream((Options.JOB_NAME + "=builder-demo").getBytes(UTF_8)));
+        OutputStream out = new ByteArrayOutputStream();
+        when(exchange.getResponseBody()).thenReturn(out);
+
+        JobBuilderService service = mock(JobBuilderService.class);
+        when(service.launchJob(anyMap())).thenReturn(new JobBuilderService.JobLaunchResult("job-123", "builder-demo", "/job-123"));
+
+        JobBuilderHandler handler = new JobBuilderHandler(service);
+        handler.handle(exchange);
+
+        verify(service).launchJob(org.mockito.ArgumentMatchers.argThat(params -> "builder-demo".equals(params.get(Options.JOB_NAME))));
+        assertTrue(out.toString().contains("\"jobId\":\"job-123\""));
+        assertTrue(out.toString().contains("\"jobPath\":\"/job-123\""));
+    }
+}

--- a/src/test/java/com/marklogic/developer/corb/JobBuilderServiceTest.java
+++ b/src/test/java/com/marklogic/developer/corb/JobBuilderServiceTest.java
@@ -1,0 +1,112 @@
+/*
+ * * Copyright (c) 2004-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * *
+ * * The use of the Apache License does not indicate that this project is
+ * * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.marklogic.developer.corb.util.StringUtils.isNotEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JobBuilderServiceTest {
+
+    @Test
+    void buildMetadataJsonIncludesGroupedOptions() {
+        JobBuilderService service = new JobBuilderService(null);
+
+        String json = service.buildMetadataJson();
+
+        assertTrue(json.contains("\"id\":\"connection\""));
+        assertTrue(json.contains("\"name\":\"XCC-CONNECTION-URI\""));
+        assertTrue(json.contains("\"id\":\"security\""));
+        assertTrue(json.contains("\"name\":\"SSL-CONFIG-CLASS\""));
+        assertTrue(json.contains("\"id\":\"retry\""));
+        assertTrue(json.contains("\"name\":\"QUERY-RETRY-LIMIT\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"INIT\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"XML\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"EXPORT-FILE\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"METRICS\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"URIS\""));
+        assertTrue(json.contains("\"subgroupTitle\":\"LOADER\""));
+        assertFalse(json.contains("\"name\":\"XQUERY-MODULE\""));
+    }
+
+    @Test
+    void reflectedBuilderCatalogIncludesAllSupportedPublicOptions() {
+        JobBuilderService service = new JobBuilderService(null);
+
+        int reflectedCount = 0;
+        for (Field field : Options.class.getDeclaredFields()) {
+            if (String.class.equals(field.getType())
+                && Modifier.isPublic(field.getModifiers())
+                && field.getAnnotation(Usage.class) != null
+                && field.getAnnotation(Deprecated.class) == null) {
+                Usage usage = field.getAnnotation(Usage.class);
+                if (isNotEmpty(usage.description())) {
+                    reflectedCount++;
+                }
+            }
+        }
+
+        int builderCount = 0;
+        for (JobBuilderService.OptionGroup group : service.getOptionGroups()) {
+            builderCount += group.getOptionCount();
+        }
+
+        assertEquals(reflectedCount, builderCount);
+    }
+
+    @Test
+    void buildPropertiesFileMergesAdditionalPropertiesAndLetsUiValuesWin() throws Exception {
+        JobBuilderService service = new JobBuilderService(null);
+        Map<String, String> values = new HashMap<>();
+        values.put(JobBuilderService.PARAM_ADDITIONAL_PROPERTIES, "CUSTOM-OPTION=true\nTHREAD-COUNT=2\nPROCESS-MODULE=/extra/process.xqy\n");
+        values.put(Options.PROCESS_MODULE, "/main/process.xqy");
+        values.put(Options.THREAD_COUNT, "8");
+        values.put(Options.JOB_NAME, "builder-job");
+        values.put("UNSUPPORTED-FORM-OPTION", "ignored");
+
+        String text = service.buildPropertiesFile(values);
+        Properties properties = new Properties();
+        properties.load(new StringReader(text));
+
+        assertEquals("/main/process.xqy", properties.getProperty(Options.PROCESS_MODULE));
+        assertEquals("8", properties.getProperty(Options.THREAD_COUNT));
+        assertEquals("builder-job", properties.getProperty(Options.JOB_NAME));
+        assertEquals("true", properties.getProperty("CUSTOM-OPTION"));
+        assertFalse(properties.containsKey("UNSUPPORTED-FORM-OPTION"));
+    }
+
+    @Test
+    void resolveDownloadFilenameSanitizesPathAndAddsExtension() {
+        JobBuilderService service = new JobBuilderService(null);
+        Map<String, String> values = new HashMap<>();
+        values.put(JobBuilderService.PARAM_DOWNLOAD_FILE_NAME, "../nightly-export");
+
+        assertEquals("..-nightly-export.properties", service.resolveDownloadFilename(values));
+    }
+}

--- a/src/test/java/com/marklogic/developer/corb/JobServerTest.java
+++ b/src/test/java/com/marklogic/developer/corb/JobServerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Collections;
@@ -55,9 +56,13 @@ class JobServerTest {
             URL url = new URL(localhostUrl );
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod(GET);
-            byte[] content = IOUtils.toByteArray(conn.getInputStream());
-            assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
-            assertNotNull(content);
+             byte[] content = IOUtils.toByteArray(conn.getInputStream());
+             assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+             assertNotNull(content);
+             assertTrue(new String(content).contains("Options Builder"));
+             assertTrue(new String(content).contains("options-builder-content"));
+             assertTrue(new String(content).contains("toggleBuilderDescription(option.name)"));
+             assertTrue(new String(content).contains(":title=\"option.description || ''\""));
 
             url = new URL(localhostUrl + "/");
             conn = (HttpURLConnection) url.openConnection();
@@ -123,5 +128,40 @@ class JobServerTest {
         server.addManager(manager);
         assertNotNull(manager.jobServer);
         assertEquals(server, manager.jobServer);
+    }
+
+    @Test
+    void testOptionsBuilderMetadataAndPropertiesEndpoints() throws Exception {
+        int port = 9994;
+        String localhostUrl = "http://localhost:" + port;
+        JobServer server = JobServer.create(port);
+        server.start();
+
+        try {
+            URL url = new URL(localhostUrl + JobBuilderHandler.BUILDER_METADATA_PATH);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            String metadata = new String(IOUtils.toByteArray(conn.getInputStream()));
+            assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+            assertTrue(metadata.contains("\"groups\""));
+            assertTrue(metadata.contains("XCC-CONNECTION-URI"));
+
+            url = new URL(localhostUrl + JobBuilderHandler.BUILDER_PROPERTIES_PATH);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
+            try (OutputStream out = conn.getOutputStream()) {
+                out.write((Options.PROCESS_MODULE + "=%2Fext%2Fprocess.xqy&" + JobBuilderService.PARAM_ADDITIONAL_PROPERTIES + "=CUSTOM-OPTION%3Dtrue").getBytes());
+            }
+            String properties = new String(IOUtils.toByteArray(conn.getInputStream()));
+            assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+            assertEquals("text/plain; charset=utf-8", conn.getHeaderField(JobServer.HEADER_CONTENT_TYPE));
+            assertTrue(conn.getHeaderField("Content-Disposition").contains("corb-job.properties"));
+            assertTrue(properties.contains("PROCESS-MODULE=/ext/process.xqy"));
+            assertTrue(properties.contains("CUSTOM-OPTION=true"));
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
Adding a UI to give users an HTML form to fill in CoRB options and either download the options file, or run a job.

<img width="1676" height="1039" alt="Screenshot 2026-03-28 at 10 47 01 PM" src="https://github.com/user-attachments/assets/b0e32df4-7ae7-47cb-a24e-01d143898c18" />

Added JobServer main method, and changed the jar manifest to set that main method as default and expect the current version of XCC to be in the same directory, allowing to invoke with just `java -jar marklogic-corb-2.6.0.jar` (and optionally specify a desired port number or range i.e. `java -jar marklogic-corb-2.6.0.jar 8888`

The Option Builder will work without XCC on the classpath, but any attempt to run the job or use the Job Status that makes calls to the backend and need to use XCC will throw classdefnotfound errors if XCC is not available.

Instead of relying on the jar metadata for tha path, can also invoke the JobServer main method with a custom classpath, similar to invoking the Manager:

    java -cp lib/* com.marklogic.developer.corb.JobServer 8888

