### PR TITLE
Added support Jasypt IvGenerators

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/JasyptDecrypter.java
+++ b/src/main/java/com/marklogic/developer/corb/JasyptDecrypter.java
@@ -20,9 +20,12 @@ package com.marklogic.developer.corb;
 
 import static com.marklogic.developer.corb.AbstractManager.loadPropertiesFile;
 import static com.marklogic.developer.corb.Options.JASYPT_PROPERTIES_FILE;
+import static com.marklogic.developer.corb.Options.JASYPT_STRING_ENCRYPTER;
+import static com.marklogic.developer.corb.Options.JASYPT_IV_GENERATOR;
 import static com.marklogic.developer.corb.util.StringUtils.isBlank;
 import static com.marklogic.developer.corb.util.StringUtils.isNotBlank;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
@@ -103,6 +106,16 @@ public class JasyptDecrypter extends AbstractDecrypter {
     protected static final Logger LOG = Logger.getLogger(JasyptDecrypter.class.getName());
 
     /**
+     *  Default algorithm to use if not explicitly specified.
+     */
+    protected static final String DEFAULT_ALGORITHM = "PBEWithMD5AndTripleDES";
+
+    /**
+     * Default encrypter/decrypter class to use if not explicitly specified.
+     */
+    protected static final String DEFAULT_ENCRYPTER = "org.jasypt.encryption.pbe.StandardPBEStringEncryptor";
+
+    /**
      * Initializes the Jasypt decrypter by loading configuration properties and
      * setting up the StandardPBEStringEncryptor instance via reflection.
      * <p>
@@ -127,15 +140,56 @@ public class JasyptDecrypter extends AbstractDecrypter {
         }
         jaspytProperties = loadPropertiesFile(decryptPropsFile, false);
 
+        do_init_decrypter();
+    }
+
+    /**
+     * Split the init_decrypter into two methods to facilitate unit testing.
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    protected void do_init_decrypter() throws IOException, ClassNotFoundException {
         String algorithm = jaspytProperties.getProperty("jasypt.algorithm");
         if (isBlank(algorithm)) {
-            algorithm = "PBEWithMD5AndTripleDES"; // select a secure algorithm as default
+            algorithm = DEFAULT_ALGORITHM; // select a secure algorithm as default
         }
         String passphrase = jaspytProperties.getProperty("jasypt.password");
         if (isNotBlank(passphrase)) {
             try {
-                decrypterCls = Class.forName("org.jasypt.encryption.pbe.StandardPBEStringEncryptor");
+                String decrypterClassName = getProperty(JASYPT_STRING_ENCRYPTER);
+                if(isBlank(decrypterClassName)) {
+                    decrypterClassName = DEFAULT_ENCRYPTER;
+                }
+
+                decrypterCls = Class.forName(decrypterClassName);
                 decrypter = decrypterCls.newInstance();
+
+                String ivGeneratorClsName = getProperty(JASYPT_IV_GENERATOR);
+                if(isNotBlank(ivGeneratorClsName)) {
+                    String[] tokens = ivGeneratorClsName.split(",");
+                    ivGeneratorClsName = tokens[0];
+
+                    String arg = null;
+                    if(tokens.length > 1 && isNotBlank(tokens[1])) {
+                        arg = tokens[1];
+                    }
+
+                    Class<?> ivGeneratorCls = Class.forName(ivGeneratorClsName);
+                    Object ivGenerator = null;
+                    if(arg == null) {
+                        ivGenerator = ivGeneratorCls.newInstance();
+                    }else{
+                        Constructor<?> constructor = ivGeneratorCls.getConstructor(String.class);
+                        ivGenerator = constructor.newInstance(arg);
+                    }
+
+                    Class<?> ivGeneratorInterface = Class.forName("org.jasypt.iv.IvGenerator");
+                    Method setIvGenerator = decrypterCls.getMethod("setIvGenerator", ivGeneratorInterface);
+                    setIvGenerator.invoke(decrypter, ivGenerator);
+                }else{
+                    LOG.info(JASYPT_IV_GENERATOR+" is blank or not specified.");
+                }
+
                 Method setAlgorithm = decrypterCls.getMethod("setAlgorithm", String.class);
                 setAlgorithm.invoke(decrypter, algorithm);
 
@@ -145,13 +199,12 @@ public class JasyptDecrypter extends AbstractDecrypter {
             } catch (ClassNotFoundException exc) {
                 throw exc;
             } catch (Exception exc) {
-                throw new IllegalStateException("Unable to initialize org.jasypt.encryption.pbe.StandardPBEStringEncryptor - check if jasypt libraries are in classpath", exc);
+                throw new IllegalStateException("Unable to initialize string decrypter or IvGenerator - check if jasypt libraries are in classpath", exc);
             }
         } else {
             LOG.severe("Unable to initialize jasypt decrypter. Couldn't find jasypt.password");
         }
     }
-
     /**
      * Decrypts the given encrypted value using the configured Jasypt decrypter.
      * <p>

--- a/src/main/java/com/marklogic/developer/corb/Options.java
+++ b/src/main/java/com/marklogic/developer/corb/Options.java
@@ -682,6 +682,26 @@ public final class Options {
     public static final String JASYPT_PROPERTIES_FILE = "JASYPT-PROPERTIES-FILE";
 
     /**
+     * (Optional) Encrypter class to decrypt encrypted credentials or connection strings that were
+     * encrypted using the jasypt api.
+     * Refer to {@link com.marklogic.developer.corb.JasyptDecrypter}.
+     * If not specified, it uses default org.jasypt.encryption.pbe.StandardPBEStringEncryptor
+     */
+    @Usage(description = "(Optional) Default is org.jasypt.encryption.pbe.StandardPBEStringEncryptor." +
+        "Jasypt encrypter class used to decrypt credentials as strings.")
+    public static final String JASYPT_STRING_ENCRYPTER = "JASYPT-STRING-ENCRYPTER";
+
+    /**
+     * (Optional) Initialization vector generator class name for jasypt v1.9.3 or above for
+     * {@link com.marklogic.developer.corb.JasyptDecrypter} that implements org.jasypt.iv.IvGenerator interface.
+     * e.g. org.jasypt.iv.RandomIvGenerator, "org.jasypt.iv.StringFixedIvGenerator,charset" etc.
+     * Refer to jasypt documentation for details.
+     */
+    @Usage(description = "(Optional) Supported since Jasypt v1.9.3. Initialization " +
+        "vector generator for encryption operations.")
+    public static final String JASYPT_IV_GENERATOR = "JASYPT-IV-GENERATOR";
+
+    /**
      * Default is 10. Max number of custom inputs from the {@value #URIS_MODULE}
      * to other modules.
      * @since 2.4.5

--- a/src/test/java/com/marklogic/developer/corb/JasyptDecrypterTest.java
+++ b/src/test/java/com/marklogic/developer/corb/JasyptDecrypterTest.java
@@ -88,6 +88,104 @@ class JasyptDecrypterTest {
     }
 
     @Test
+    void testInitWithCustomEncrypter() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_STRING_ENCRYPTER, "org.jasypt.encryption.pbe.PooledPBEStringEncryptor");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        assertEquals(UNENCRYPTED_PASSWORD, instance.jaspytProperties.getProperty(JASYPT_PASSWORD));
+    }
+
+    @Test
+    void testInitWithCustomInvalidEncrypter() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_STRING_ENCRYPTER, "org.jasypt.encryption.pbe.PooledPBEStringEncryptorrs");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+            fail();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.INFO, "Expected with an invalid value test", ex);
+        }
+    }
+
+    @Test
+    void testInitWithIvGenerator() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.RandomIvGenerator");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        assertEquals(UNENCRYPTED_PASSWORD, instance.jaspytProperties.getProperty(JASYPT_PASSWORD));
+    }
+
+    @Test
+    void testInitWithInvalidIvGenerator() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.RandomIvGeneratorrs");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+            fail();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.INFO, "Expected with an invalid value test", ex);
+        }
+    }
+
+    @Test
+    void testInitWithStringIvGeneratorWithtCharset() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.StringFixedIvGenerator,charset");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.INFO, "", ex);
+            fail();
+        }
+    }
+
+    @Test
+    void testInitWithStringIvGeneratorWithoutCharset() {
+        clearSystemProperties();
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.StringFixedIvGenerator");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.properties = props;
+        try {
+            instance.init_decrypter();
+            fail();
+        } catch (IOException | ClassNotFoundException | IllegalStateException ex) {
+            LOG.log(Level.INFO, "Expected with an invalid value test", ex);
+        }
+    }
+
+    @Test
     void testDoDecrypt() {
         String property = "prop1";
         String value = "value";
@@ -118,6 +216,196 @@ class JasyptDecrypterTest {
         instance.decrypter = null;
         String result = instance.doDecrypt(property, value);
         assertEquals(value, result);
+    }
+
+    @Test
+    void testDoDecryptJasyptWithProperties() {
+        String property = "property";
+        String value = "RBSskx1057hdi1qWe0ugXg==";
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertEquals("value", result);
+    }
+
+    @Test
+    void testDoDecryptInvalidValueWithProperties() {
+        String property = "property";
+        String value = "RBSskx1057hdi1qWe0ugXg==xx";
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
+    }
+
+    @Test
+    void testDoDecryptInvalidAlgorithmWithProperties() {
+        String property = "property";
+        String value = "RBSskx1057hdi1qWe0ugXg==";
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES1");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
+    }
+
+    @Test
+    void testDoDecryptInvalidPassphraseWithProperties() {
+        String property = "property";
+        String value = "RBSskx1057hdi1qWe0ugXg==";
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password1");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
+    }
+
+    @Test
+    void testDoDecryptWithIVGenerator() {
+        String property = "property";
+        String value = "OvlChyf73qNC7DB9tSPDWqDQTnGR3+oo";
+
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.RandomIvGenerator");
+
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+
+        instance.properties = props;
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertEquals("value", result);
+    }
+
+    @Test
+    void testDoDecryptWithMissingIVGenerator() {
+        String property = "property";
+        String value = "OvlChyf73qNC7DB9tSPDWqDQTnGR3+oo";
+
+        Properties props = new Properties();
+        //props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.RandomIvGenerator");
+
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+
+        instance.properties = props;
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
+    }
+
+    @Test
+    void testDoDecryptInvalidValueWithIVGenerator() {
+        String property = "property";
+        String value = "OvlChyf73qNC7DB9tSPDWqDQTnGR3";
+
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.RandomIvGenerator");
+
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+
+        instance.properties = props;
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
+    }
+
+    @Test
+    void testDoDecryptWithWrongIVGenerator() {
+        String property = "property";
+        String value = "OvlChyf73qNC7DB9tSPDWqDQTnGR3+oo";
+
+        Properties props = new Properties();
+        props.setProperty(Options.JASYPT_IV_GENERATOR, "org.jasypt.iv.StringFixedIvGenerator,charset");
+
+        Properties jasyptProps = new Properties();
+        jasyptProps.setProperty("jasypt.password", "password");
+        jasyptProps.setProperty("jasypt.algorithm", "PBEWithMD5AndTripleDES");
+        JasyptDecrypter instance = new JasyptDecrypter();
+
+        instance.properties = props;
+        instance.jaspytProperties = jasyptProps;
+        try {
+            instance.do_init_decrypter();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.log(Level.SEVERE, "", ex);
+            fail();
+        }
+
+        String result = instance.doDecrypt(property, value);
+        assertNotEquals("value", result);
+        assertEquals(value, result); //should get original value if unable to decrypt
     }
 
     private static class TestDecrypt {


### PR DESCRIPTION
Added support for Initialization Vector generator for Jasypt encryption which is available since v1.9.3. Corb implementations with older jasypt versions should not be affected by this change. Even with newer jasypt, this change will kick in only if optional iv generator class is explicitly specified in corb properties file. Added several test cases around jasypt encryption. 